### PR TITLE
docs: add developer guide and function catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Binaries
+mcp-server
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# Go coverage files
+*.cover
+*.coverprofile
+
+# Logs
+*.log
+
+# Build directories
+bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Developer Guide
+
+This repository contains `mcp-shell`, a Model Context Protocol (MCP) server written in Go.
+
+## Project structure
+- `main.go`: entry point that configures transports and registers tools.
+- `internal/`: Go packages implementing each tool (e.g. `internal/shell` for `shell.exec`).
+- `doc/`: documentation such as the function catalogue.
+- `.github/workflows/`: CI configuration.
+
+## Development workflow
+- Use `go fmt ./...` for formatting.
+- Use `go build ./...` to ensure the project builds.
+- Use `go test ./...` to run tests (even if none yet exist).
+- A convenience `Makefile` is provided; `make fmt build test` runs all of the above.
+
+Before submitting code, run the commands above and ensure they succeed.
+
+## Documentation
+Keep `doc/functions.md` up to date whenever tools or endpoints are added or changed.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt build test all
+
+fmt:
+	go fmt ./...
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+all: fmt build test

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
 - **Primary tool**: `shell.exec` (run a shell command inside the container).
+- **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.
 - **Security model**: Execution is confined to a non-root user in a container. You control:
   - Host mounts (read-only vs read-write).
   - Network egress (enable/disable at run-time).

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -1,0 +1,11 @@
+# Function Reference
+
+List of functions exposed by `mcp-shell`.
+
+| Function | Arguments | Output | Description |
+| --- | --- | --- | --- |
+| `GET /healthz` | none | `{status:"ok", name, version, uptime}` | Basic liveness probe |
+| `GET /readyz` | none | `{status:"ok", name, version, uptime}` | Readiness probe |
+| `GET /mcp/health` | none | `{status:"ok", name, version, uptime}` | MCP-native health endpoint |
+| `shell.exec` | `cmd` (string, required), `cwd?`, `env?`, `timeout_ms?`, `stdin?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Execute a shell command in the container |
+


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with project layout and development workflow
- document existing endpoints and `shell.exec` in `doc/functions.md`
- add Makefile and `.gitignore`, note function reference in README

## Testing
- `go fmt ./...`
- `make build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6ce21d2d0832c9d9092cd52fcd6bc