### PR TITLE
Add filesystem tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tool**: `shell.exec` (run a shell command inside the container).
+- **Primary tools**: `shell.exec` (run a shell command) and `fs.*` (list, stat, read, write, and other basic filesystem ops).
 - **Security model**: Execution is confined to a non-root user in a container. You control:
   - Host mounts (read-only vs read-write).
   - Network egress (enable/disable at run-time).
@@ -150,7 +150,7 @@ curl -sS -H 'content-type: application/json' \
   -X POST http://127.0.0.1:3333/mcp/ \
   -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
 
-# 3) List tools (expect "shell.exec")
+# 3) List tools (expect "shell.exec" and "fs.*" tools)
 curl -sS -H 'content-type: application/json' -H "Mcp-Session-Id: $SID" \
   -X POST http://127.0.0.1:3333/mcp/ \
   -d '{"jsonrpc":"2.0","id":"2","method":"tools/list"}' | jq .

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1,0 +1,644 @@
+package fs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	stdfs "io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf8"
+)
+
+const LogPath = "/logs/mcp-shell.log"
+
+// workspaceRoot returns the root directory for filesystem operations.
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func allowOutside() bool {
+	v := os.Getenv("FS_ALLOW_OUTSIDE_WORKSPACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// normalizePath cleans the path and ensures it stays within the workspace root
+// unless FS_ALLOW_OUTSIDE_WORKSPACE is set.
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	if allowOutside() {
+		return p, nil
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path %q escapes workspace", p)
+	}
+	return p, nil
+}
+
+// audit writes a JSONL record to LogPath; failures are ignored.
+func audit(rec any) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+// ---- fs.list
+
+type ListRequest struct {
+	Path          string `json:"path"`
+	Glob          string `json:"glob,omitempty"`
+	IncludeHidden bool   `json:"include_hidden,omitempty"`
+	MaxEntries    int    `json:"max_entries,omitempty"`
+}
+
+type ListEntry struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Size  int64  `json:"size"`
+	Mtime int64  `json:"mtime"`
+	Mode  string `json:"mode"`
+}
+
+type ListResponse struct {
+	Entries    []ListEntry `json:"entries"`
+	DurationMs int64       `json:"duration_ms"`
+	Error      string      `json:"error,omitempty"`
+}
+
+func List(ctx context.Context, in ListRequest) ListResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return ListResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return ListResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	resp := ListResponse{}
+	for _, e := range entries {
+		name := e.Name()
+		if !in.IncludeHidden && strings.HasPrefix(name, ".") {
+			continue
+		}
+		if in.Glob != "" {
+			match, _ := filepath.Match(in.Glob, name)
+			if !match {
+				continue
+			}
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		typ := "file"
+		if info.IsDir() {
+			typ = "dir"
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			typ = "symlink"
+		}
+		resp.Entries = append(resp.Entries, ListEntry{
+			Name:  name,
+			Type:  typ,
+			Size:  info.Size(),
+			Mtime: info.ModTime().Unix(),
+			Mode:  fmt.Sprintf("%#o", info.Mode().Perm()),
+		})
+		if in.MaxEntries > 0 && len(resp.Entries) >= in.MaxEntries {
+			break
+		}
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		Count      int    `json:"count"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.list", path, resp.DurationMs, len(resp.Entries)})
+	return resp
+}
+
+// ---- fs.stat
+
+type StatRequest struct {
+	Path string `json:"path"`
+}
+
+type StatResponse struct {
+	Type       string `json:"type"`
+	Size       int64  `json:"size"`
+	Mode       string `json:"mode"`
+	Mtime      int64  `json:"mtime"`
+	UID        uint32 `json:"uid"`
+	GID        uint32 `json:"gid"`
+	Target     string `json:"symlink_target,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Stat(ctx context.Context, in StatRequest) StatResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return StatResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return StatResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	typ := "file"
+	if info.IsDir() {
+		typ = "dir"
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		typ = "symlink"
+	}
+	var uid, gid uint32
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		uid = stat.Uid
+		gid = stat.Gid
+	}
+	resp := StatResponse{
+		Type:  typ,
+		Size:  info.Size(),
+		Mode:  fmt.Sprintf("%#o", info.Mode().Perm()),
+		Mtime: info.ModTime().Unix(),
+		UID:   uid,
+		GID:   gid,
+	}
+	if typ == "symlink" {
+		if target, err := os.Readlink(path); err == nil {
+			resp.Target = target
+		}
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.stat", path, resp.DurationMs})
+	return resp
+}
+
+// ---- fs.read
+
+type ReadRequest struct {
+	Path        string `json:"path"`
+	MaxBytes    int64  `json:"max_bytes,omitempty"`
+	StartOffset int64  `json:"start_offset,omitempty"`
+}
+
+type ReadResponse struct {
+	Content    string `json:"content"`
+	Truncated  bool   `json:"truncated"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Read(ctx context.Context, in ReadRequest) ReadResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if in.StartOffset > 0 {
+		if _, err := f.Seek(in.StartOffset, io.SeekStart); err != nil {
+			return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	limit := in.MaxBytes
+	if limit <= 0 {
+		limit = info.Size() - in.StartOffset
+	}
+	data, err := io.ReadAll(io.LimitReader(f, limit))
+	if err != nil {
+		return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	truncated := in.StartOffset+int64(len(data)) < info.Size()
+	if !utf8.Valid(data) {
+		return ReadResponse{DurationMs: time.Since(start).Milliseconds(), Error: "file is not valid UTF-8"}
+	}
+	resp := ReadResponse{Content: string(data), Truncated: truncated}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		BytesOut   int    `json:"bytes_out"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.read", path, resp.DurationMs, len(data)})
+	return resp
+}
+
+// ---- fs.read_b64
+
+type ReadB64Response struct {
+	ContentB64 string `json:"content_b64"`
+	Truncated  bool   `json:"truncated"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func ReadB64(ctx context.Context, in ReadRequest) ReadB64Response {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return ReadB64Response{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ReadB64Response{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return ReadB64Response{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if in.StartOffset > 0 {
+		if _, err := f.Seek(in.StartOffset, io.SeekStart); err != nil {
+			return ReadB64Response{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	limit := in.MaxBytes
+	if limit <= 0 {
+		limit = info.Size() - in.StartOffset
+	}
+	data, err := io.ReadAll(io.LimitReader(f, limit))
+	if err != nil {
+		return ReadB64Response{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	truncated := in.StartOffset+int64(len(data)) < info.Size()
+	resp := ReadB64Response{ContentB64: base64.StdEncoding.EncodeToString(data), Truncated: truncated}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		BytesOut   int    `json:"bytes_out"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.read_b64", path, resp.DurationMs, len(resp.ContentB64)})
+	return resp
+}
+
+// ---- fs.write
+
+type WriteRequest struct {
+	Path          string `json:"path"`
+	Content       string `json:"content,omitempty"`
+	ContentB64    string `json:"content_b64,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+	CreateParents bool   `json:"create_parents,omitempty"`
+	Append        bool   `json:"append,omitempty"`
+	DryRun        bool   `json:"dry_run,omitempty"`
+}
+
+type WriteResponse struct {
+	BytesWritten int    `json:"bytes_written"`
+	DurationMs   int64  `json:"duration_ms"`
+	Error        string `json:"error,omitempty"`
+}
+
+func Write(ctx context.Context, in WriteRequest) WriteResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return WriteResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	var data []byte
+	switch {
+	case in.ContentB64 != "":
+		b, err := base64.StdEncoding.DecodeString(in.ContentB64)
+		if err != nil {
+			return WriteResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		data = b
+	default:
+		data = []byte(in.Content)
+	}
+	perm := os.FileMode(0o644)
+	if in.Mode != "" {
+		if v, err := strconv.ParseUint(in.Mode, 8, 32); err == nil {
+			perm = os.FileMode(v)
+		}
+	}
+	if in.CreateParents {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return WriteResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	if in.DryRun {
+		resp := WriteResponse{BytesWritten: len(data)}
+		resp.DurationMs = time.Since(start).Milliseconds()
+		audit(struct {
+			TS           string `json:"ts"`
+			Tool         string `json:"tool"`
+			Path         string `json:"path"`
+			DurationMs   int64  `json:"duration_ms"`
+			BytesWritten int    `json:"bytes_written"`
+			DryRun       bool   `json:"dry_run"`
+		}{time.Now().UTC().Format(time.RFC3339), "fs.write", path, resp.DurationMs, resp.BytesWritten, true})
+		return resp
+	}
+	flags := os.O_CREATE | os.O_WRONLY
+	if in.Append {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(path, flags, perm)
+	if err != nil {
+		return WriteResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer f.Close()
+	n, err := f.Write(data)
+	if err != nil {
+		return WriteResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	resp := WriteResponse{BytesWritten: n}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS           string `json:"ts"`
+		Tool         string `json:"tool"`
+		Path         string `json:"path"`
+		DurationMs   int64  `json:"duration_ms"`
+		BytesWritten int    `json:"bytes_written"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.write", path, resp.DurationMs, n})
+	return resp
+}
+
+// ---- fs.remove
+
+type RemoveRequest struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+
+type RemoveResponse struct {
+	Removed    bool   `json:"removed"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Remove(ctx context.Context, in RemoveRequest) RemoveResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return RemoveResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	var rerr error
+	if in.Recursive {
+		rerr = os.RemoveAll(path)
+	} else {
+		rerr = os.Remove(path)
+	}
+	resp := RemoveResponse{Removed: rerr == nil}
+	if rerr != nil {
+		resp.Error = rerr.Error()
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		Removed    bool   `json:"removed"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.remove", path, resp.DurationMs, resp.Removed})
+	return resp
+}
+
+// ---- fs.mkdir
+
+type MkdirRequest struct {
+	Path    string `json:"path"`
+	Parents bool   `json:"parents,omitempty"`
+	Mode    string `json:"mode,omitempty"`
+}
+
+type MkdirResponse struct {
+	Created    bool   `json:"created"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Mkdir(ctx context.Context, in MkdirRequest) MkdirResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return MkdirResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	perm := os.FileMode(0o755)
+	if in.Mode != "" {
+		if v, err := strconv.ParseUint(in.Mode, 8, 32); err == nil {
+			perm = os.FileMode(v)
+		}
+	}
+	var merr error
+	if in.Parents {
+		merr = os.MkdirAll(path, perm)
+	} else {
+		merr = os.Mkdir(path, perm)
+	}
+	resp := MkdirResponse{Created: merr == nil}
+	if merr != nil {
+		resp.Error = merr.Error()
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		Created    bool   `json:"created"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.mkdir", path, resp.DurationMs, resp.Created})
+	return resp
+}
+
+// ---- fs.move
+
+type MoveRequest struct {
+	Src       string `json:"src"`
+	Dest      string `json:"dest"`
+	Overwrite bool   `json:"overwrite,omitempty"`
+	Parents   bool   `json:"parents,omitempty"`
+}
+
+type MoveResponse struct {
+	Moved      bool   `json:"moved"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Move(ctx context.Context, in MoveRequest) MoveResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return MoveResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return MoveResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if !in.Overwrite {
+		if _, err := os.Stat(dest); err == nil {
+			return MoveResponse{DurationMs: time.Since(start).Milliseconds(), Error: "destination exists"}
+		}
+	}
+	if in.Parents {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return MoveResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	err = os.Rename(src, dest)
+	resp := MoveResponse{Moved: err == nil}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		DurationMs int64  `json:"duration_ms"`
+		Moved      bool   `json:"moved"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.move", src, dest, resp.DurationMs, resp.Moved})
+	return resp
+}
+
+// ---- fs.copy
+
+type CopyRequest struct {
+	Src       string `json:"src"`
+	Dest      string `json:"dest"`
+	Overwrite bool   `json:"overwrite,omitempty"`
+	Parents   bool   `json:"parents,omitempty"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+
+type CopyResponse struct {
+	Copied     bool   `json:"copied"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Copy(ctx context.Context, in CopyRequest) CopyResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if !in.Overwrite {
+		if _, err := os.Stat(dest); err == nil {
+			return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: "destination exists"}
+		}
+	}
+	if in.Parents {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	info, err := os.Lstat(src)
+	if err != nil {
+		return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if info.IsDir() {
+		if !in.Recursive {
+			return CopyResponse{DurationMs: time.Since(start).Milliseconds(), Error: "source is a directory"}
+		}
+		err = filepath.WalkDir(src, func(path string, d stdfs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(src, path)
+			if err != nil {
+				return err
+			}
+			target := filepath.Join(dest, rel)
+			if d.IsDir() {
+				return os.MkdirAll(target, 0o755)
+			}
+			if d.Type()&os.ModeSymlink != 0 {
+				linkTarget, err := os.Readlink(path)
+				if err != nil {
+					return err
+				}
+				return os.Symlink(linkTarget, target)
+			}
+			return copyFile(path, target, info.Mode())
+		})
+	} else {
+		err = copyFile(src, dest, info.Mode())
+	}
+	resp := CopyResponse{Copied: err == nil}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		DurationMs int64  `json:"duration_ms"`
+		Copied     bool   `json:"copied"`
+	}{time.Now().UTC().Format(time.RFC3339), "fs.copy", src, dest, resp.DurationMs, resp.Copied})
+	return resp
+}
+
+func copyFile(src, dest string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -1,0 +1,93 @@
+package fs
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFSRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+
+	// Write a file
+	if resp := Write(ctx, WriteRequest{Path: "dir/file.txt", Content: "hello", CreateParents: true}); resp.Error != "" {
+		t.Fatalf("write error: %v", resp.Error)
+	}
+
+	// Read the file
+	if resp := Read(ctx, ReadRequest{Path: "dir/file.txt"}); resp.Error != "" || resp.Content != "hello" {
+		t.Fatalf("read got %+v", resp)
+	}
+
+	// Read base64
+	if resp := ReadB64(ctx, ReadRequest{Path: "dir/file.txt"}); resp.Error != "" {
+		t.Fatalf("read_b64 error: %v", resp.Error)
+	} else if b, _ := base64.StdEncoding.DecodeString(resp.ContentB64); string(b) != "hello" {
+		t.Fatalf("read_b64 content %q", b)
+	}
+
+	// Stat directory
+	if resp := Stat(ctx, StatRequest{Path: "dir"}); resp.Error != "" || resp.Type != "dir" {
+		t.Fatalf("stat dir got %+v", resp)
+	}
+
+	// List directory
+	if resp := List(ctx, ListRequest{Path: "dir"}); resp.Error != "" || len(resp.Entries) != 1 {
+		t.Fatalf("list got %+v", resp)
+	}
+
+	// Copy file
+	if resp := Copy(ctx, CopyRequest{Src: "dir/file.txt", Dest: "dir/copy.txt"}); resp.Error != "" {
+		t.Fatalf("copy error: %v", resp.Error)
+	}
+
+	// Move file
+	if resp := Move(ctx, MoveRequest{Src: "dir/copy.txt", Dest: "dir/moved.txt"}); resp.Error != "" {
+		t.Fatalf("move error: %v", resp.Error)
+	}
+
+	// Remove files
+	if resp := Remove(ctx, RemoveRequest{Path: "dir/moved.txt"}); resp.Error != "" {
+		t.Fatalf("remove error: %v", resp.Error)
+	}
+	if resp := Remove(ctx, RemoveRequest{Path: "dir/file.txt"}); resp.Error != "" {
+		t.Fatalf("remove error: %v", resp.Error)
+	}
+
+	// Mkdir
+	if resp := Mkdir(ctx, MkdirRequest{Path: "dir/sub/sub2", Parents: true}); resp.Error != "" || !resp.Created {
+		t.Fatalf("mkdir got %+v", resp)
+	}
+
+	// Remove directory recursively
+	if resp := Remove(ctx, RemoveRequest{Path: "dir", Recursive: true}); resp.Error != "" {
+		t.Fatalf("remove dir error: %v", resp.Error)
+	}
+}
+
+func TestPathEscapeDenied(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	outside := filepath.Join(ws, "..", "haxx")
+	if resp := Write(ctx, WriteRequest{Path: outside, Content: "hi"}); resp.Error == "" {
+		t.Fatalf("expected error for outside path")
+	}
+}
+
+func TestReadBinaryFails(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	bin := filepath.Join(ws, "bin.dat")
+	if err := os.WriteFile(bin, []byte{0xff, 0x00, 0x01}, 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	if resp := Read(ctx, ReadRequest{Path: "bin.dat"}); resp.Error == "" {
+		t.Fatalf("expected utf-8 error")
+	}
+}

--- a/internal/shell/tool_test.go
+++ b/internal/shell/tool_test.go
@@ -1,0 +1,44 @@
+package shell
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunSuccess(t *testing.T) {
+	resp := Run(context.Background(), ExecRequest{Cmd: "echo hi"})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", resp.ExitCode)
+	}
+	if strings.TrimSpace(resp.Stdout) != "hi" {
+		t.Fatalf("unexpected stdout: %q", resp.Stdout)
+	}
+}
+
+func TestRunFailure(t *testing.T) {
+	resp := Run(context.Background(), ExecRequest{Cmd: "exit 7"})
+	if resp.ExitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", resp.ExitCode)
+	}
+}
+
+func TestRunTimeout(t *testing.T) {
+	resp := Run(context.Background(), ExecRequest{Cmd: "sleep 1", TimeoutMs: 100})
+	if resp.ExitCode != 124 {
+		t.Fatalf("expected exit code 124, got %d", resp.ExitCode)
+	}
+}
+
+func TestRunStdoutTruncation(t *testing.T) {
+	resp := Run(context.Background(), ExecRequest{Cmd: "yes | head -c 2000", MaxBytes: 100})
+	if !resp.StdoutTruncated {
+		t.Fatalf("expected stdout truncated")
+	}
+	if len(resp.Stdout) > 100 {
+		t.Fatalf("stdout length %d exceeds limit", len(resp.Stdout))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	mcp "github.com/mark3labs/mcp-go/mcp"
 	server "github.com/mark3labs/mcp-go/server"
 
+	"github.com/gaspardpetit/mcp-shell/internal/fs"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
 )
 
@@ -51,6 +52,115 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "shell.exec result"), nil
 	})
 	s.AddTool(tool, handler)
+
+	// filesystem tools
+	// fs.list
+	fsListTool := mcp.NewTool(
+		"fs.list",
+		mcp.WithDescription("List directory entries"),
+		mcp.WithInputSchema[fs.ListRequest](),
+	)
+	fsListHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.ListRequest) (*mcp.CallToolResult, error) {
+		resp := fs.List(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.list result"), nil
+	})
+	s.AddTool(fsListTool, fsListHandler)
+
+	// fs.stat
+	fsStatTool := mcp.NewTool(
+		"fs.stat",
+		mcp.WithDescription("Get file or directory metadata"),
+		mcp.WithInputSchema[fs.StatRequest](),
+	)
+	fsStatHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.StatRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Stat(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.stat result"), nil
+	})
+	s.AddTool(fsStatTool, fsStatHandler)
+
+	// fs.read
+	fsReadTool := mcp.NewTool(
+		"fs.read",
+		mcp.WithDescription("Read a UTF-8 text file"),
+		mcp.WithInputSchema[fs.ReadRequest](),
+	)
+	fsReadHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.ReadRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Read(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.read result"), nil
+	})
+	s.AddTool(fsReadTool, fsReadHandler)
+
+	// fs.read_b64
+	fsReadB64Tool := mcp.NewTool(
+		"fs.read_b64",
+		mcp.WithDescription("Read a file and return base64 content"),
+		mcp.WithInputSchema[fs.ReadRequest](),
+	)
+	fsReadB64Handler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.ReadRequest) (*mcp.CallToolResult, error) {
+		resp := fs.ReadB64(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.read_b64 result"), nil
+	})
+	s.AddTool(fsReadB64Tool, fsReadB64Handler)
+
+	// fs.write
+	fsWriteTool := mcp.NewTool(
+		"fs.write",
+		mcp.WithDescription("Write a file"),
+		mcp.WithInputSchema[fs.WriteRequest](),
+	)
+	fsWriteHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.WriteRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Write(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.write result"), nil
+	})
+	s.AddTool(fsWriteTool, fsWriteHandler)
+
+	// fs.remove
+	fsRemoveTool := mcp.NewTool(
+		"fs.remove",
+		mcp.WithDescription("Remove a file or directory"),
+		mcp.WithInputSchema[fs.RemoveRequest](),
+	)
+	fsRemoveHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.RemoveRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Remove(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.remove result"), nil
+	})
+	s.AddTool(fsRemoveTool, fsRemoveHandler)
+
+	// fs.mkdir
+	fsMkdirTool := mcp.NewTool(
+		"fs.mkdir",
+		mcp.WithDescription("Create a directory"),
+		mcp.WithInputSchema[fs.MkdirRequest](),
+	)
+	fsMkdirHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.MkdirRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Mkdir(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.mkdir result"), nil
+	})
+	s.AddTool(fsMkdirTool, fsMkdirHandler)
+
+	// fs.move
+	fsMoveTool := mcp.NewTool(
+		"fs.move",
+		mcp.WithDescription("Move or rename a file"),
+		mcp.WithInputSchema[fs.MoveRequest](),
+	)
+	fsMoveHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.MoveRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Move(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.move result"), nil
+	})
+	s.AddTool(fsMoveTool, fsMoveHandler)
+
+	// fs.copy
+	fsCopyTool := mcp.NewTool(
+		"fs.copy",
+		mcp.WithDescription("Copy a file or directory"),
+		mcp.WithInputSchema[fs.CopyRequest](),
+	)
+	fsCopyHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.CopyRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Copy(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.copy result"), nil
+	})
+	s.AddTool(fsCopyTool, fsCopyHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add fs.list, fs.stat, fs.read, fs.read_b64, fs.write, fs.remove, fs.mkdir, fs.move, and fs.copy tools
- restrict filesystem access to the workspace root and audit calls
- document filesystem tooling in README
- add unit tests for filesystem tools and shell.exec

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6d1ed0098832c85c9e7de9f079c4c