### PR TITLE
refactor docker workflow to reuse tool layers

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,32 +14,127 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-tools:
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
-
     strategy:
       matrix:
         include:
           - name: light
-            branch: light
-            preset: light          # if your Dockerfile uses light|standard|full
-            dockerfile: Dockerfile
+            preset: light
             tag_prefix: "light-"
           - name: standard
-            branch: standard
             preset: standard
-            dockerfile: Dockerfile
             tag_prefix: ""
           - name: full
-            branch: full
             preset: full
-            dockerfile: Dockerfile
             tag_prefix: "full-"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Compute version metadata
+        id: meta
+        shell: bash
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+            DESCRIBE="${GITHUB_REF_NAME}"
+          else
+            DESCRIBE="$(git describe --tags --always --dirty)"
+            VERSION="${DESCRIBE}"
+          fi
+          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
+          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "major=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "minor=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "patch=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+            echo "is_clean_release=true"    >> $GITHUB_OUTPUT
+          else
+            echo "is_clean_release=false"   >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (tools ${{ matrix.name }})
+        id: dmeta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=tools-${{ matrix.tag_prefix }}sha-${{ steps.meta.outputs.sha }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}desc-${{ steps.meta.outputs.describe }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}${{ github.ref_name }},enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}v${{ steps.meta.outputs.major }}.${{ steps.meta.outputs.minor }},enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}v${{ steps.meta.outputs.major }},enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
+            type=raw,value=tools-${{ matrix.tag_prefix }}latest,enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
+
+      - name: Build and push tool image ( ${{ matrix.name }} )
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.tools
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dmeta.outputs.tags }}
+          labels: ${{ steps.dmeta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            PRESET=${{ matrix.preset }}
+
+      - name: Sign the published tool image ( ${{ matrix.name }} )
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          TAGS: ${{ steps.dmeta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  build:
+    needs: build-tools
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      matrix:
+        include:
+          - name: light
+            preset: light
+            tag_prefix: "light-"
+          - name: standard
+            preset: standard
+            tag_prefix: ""
+          - name: full
+            preset: full
+            tag_prefix: "full-"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,12 +196,21 @@ jobs:
             type=raw,value=${{ matrix.tag_prefix }}v${{ steps.meta.outputs.major }},enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
             type=raw,value=${{ matrix.tag_prefix }}latest,enable=${{ steps.meta.outputs.is_clean_release == 'true' }}
 
+      - name: Determine base image tag
+        id: base
+        run: |
+          if [[ "${{ steps.meta.outputs.is_clean_release }}" == "true" ]]; then
+            echo "tag=tools-${{ matrix.tag_prefix }}sha-${{ steps.meta.outputs.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=tools-${{ matrix.tag_prefix }}latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push Docker image ( ${{ matrix.name }} )
         id: build-and-push
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.dmeta.outputs.tags }}
           labels: ${{ steps.dmeta.outputs.labels }}
@@ -117,7 +221,7 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ steps.meta.outputs.sha }}
             BUILD_DATE=${{ steps.meta.outputs.date }}
-            PRESET=${{ matrix.preset }}
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.base.outputs.tag }}
 
       - name: Sign the published Docker image ( ${{ matrix.name }} )
         if: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,233 +1,26 @@
-# =========================
-# BUILD EXAMPLES:
-#
-# --- Default Build:
-# docker build .
-#
-# --- Build with support for French and German OCR:
-# docker build --build-arg TESS_LANGS_EXTRA="tesseract-ocr-fra tesseract-ocr-deu" .
-#
-# --- Add extra locales (English is always enabled):
-# docker build --build-arg EXTRA_LOCALES="fr_CA.UTF-8 de_DE.UTF-8" .
-
-# =========================
-# RUN EXAMPLES:
-# --- STDIO (interactive)
-# docker run -i --rm mcp-shell --transport=stdio
-#
-# --- Streamable HTTP
-# docker run --rm -p 3333:3333 mcp-shell --transport=http --addr=0.0.0.0:3333
-#
-# --- SSE
-# docker run --rm -p 3333:3333 mcp-shell --transport=sse --addr=0.0.0.0:3333
-
-# =========================
-#  Stage 1: Go builder
-# =========================
+# Stage 1: Build Go executable
 FROM golang:1.24-bookworm AS builder
-
-# Enable reliable, reproducible builds
-ENV CGO_ENABLED=0 \
-    GO111MODULE=on
 
 WORKDIR /src
 
-# Copy go.mod/sum first for better caching; then the rest
 COPY go.mod go.sum ./
 RUN go mod download
 
-
-# Copy the whole repo (assumes your main is at ./cmd/mcp-shell.go)
 COPY . .
 
-# Build the MCP server binary
-# Adjust -X flags as you like (version, commit, build time)
 RUN go build -trimpath -ldflags="-s -w" -o /out/mcp-server ./main.go
 
+# Stage 2: Final image based on prebuilt tools
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# =========================
-#  Stage 2: Runtime base
-# =========================
-FROM debian:bookworm-slim AS runtime
-
-# ---- Build-time knobs (choose your preset) ----
-# light  -> smallest, shell + core utils + python basics + poppler + pandoc
-# standard -> adds LibreOffice, ImageMagick, ffmpeg, tesseract, DuckDB, Node.js LTS
-# full     -> standard + TeX subset for high-quality PDF via pandoc/xelatex
-ARG PRESET=standard
-
-# ---- Runtime knobs (can be overridden at run-time) ----
-ENV APP_USER=user \
-    APP_UID=10001 \
-    APP_GID=10001 \
-    APP_HOME=/home/user \
-    WORKSPACE=/workspace \
-    LOG_DIR=/logs \
-    PORT=3333 \
-    LISTEN_ADDR=0.0.0.0 \
-    EGRESS=0 \
-    DEBIAN_FRONTEND=noninteractive
-
-# Base OS setup
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-      ca-certificates curl gnupg; \
-    rm -rf /var/lib/apt/lists/*
-
-# ---- Package sets (assembled by PRESET) ----
-# Core across all presets
-ENV PKGS_CORE="\
-  bash coreutils findutils grep sed gawk procps psmisc \
-  zip unzip tar gzip xz-utils p7zip-full zstd brotli \
-  ripgrep fd-find jq yq xmlstarlet jo miller python3-csvkit bat \
-  moreutils parallel \
-  file tree \
-  httpie \
-  bind9-dnsutils iputils-ping traceroute netcat-openbsd socat \
-  openssh-client rsync \
-  locales \
-  make cmake pkg-config build-essential \
-  git git-lfs \
-  openssl gpg \
-  poppler-utils pandoc \
-  python3 python3-pip python3-venv python3-distutils \
-  sqlite3"
-
-# Standard extras
-ENV PKGS_STANDARD_EXTRA="\
-  libreoffice \
-  imagemagick \
-  ffmpeg \
-  tesseract-ocr tesseract-ocr-eng \
-  ocrmypdf qpdf pdfgrep ghostscript \
-  fonts-noto fonts-noto-cjk fonts-noto-color-emoji \
-  libimage-exiftool-perl \
-  nodejs"
-
-# Full extras (TeX subset; sizable)
-ENV PKGS_FULL_EXTRA="\
-  texlive-xetex"
-
-  # Node 22.x LTS (only if standard/full chosen)
-RUN set -eux; \
-    if [ "$PRESET" != "light" ]; then \
-      curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
-      apt-get update; \
-    fi
-
-# Optional extra OCR languages (space-separated apt package names)
-ARG TESS_LANGS_EXTRA=""
-
-# Install packages based on PRESET (with preset-aware OCR defaults)
-RUN set -eux; \
-    apt-get update; \
-    case "$PRESET" in \
-      light)  tess_extra="${TESS_LANGS_EXTRA:-}";; \
-      standard) tess_extra="${TESS_LANGS_EXTRA:-"tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa tesseract-ocr-ita tesseract-ocr-por"}";; \
-      full)     tess_extra="${TESS_LANGS_EXTRA:-"tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa tesseract-ocr-ita tesseract-ocr-por tesseract-ocr-nld tesseract-ocr-swe tesseract-ocr-dan tesseract-ocr-nor tesseract-ocr-pol tesseract-ocr-ces tesseract-ocr-rus tesseract-ocr-chi-sim tesseract-ocr-chi-tra tesseract-ocr-jpn tesseract-ocr-kor"}";; \
-      *)        echo "Unknown PRESET=$PRESET"; exit 1 ;; \
-    esac; \
-    case "$PRESET" in \
-      light)  apt-get install -y --no-install-recommends $PKGS_CORE ;; \
-      standard) apt-get install -y --no-install-recommends $PKGS_CORE $PKGS_STANDARD_EXTRA $tess_extra ;; \
-      full)     apt-get install -y --no-install-recommends $PKGS_CORE $PKGS_STANDARD_EXTRA $PKGS_FULL_EXTRA $tess_extra ;; \
-    esac; \
-    apt-get autoremove -y; \
-    rm -rf /var/lib/apt/lists/*
-
-
-## ----- Locales (always English; optional extras) -----
-# EXTRA_LOCALES: space-separated list like "fr_CA.UTF-8 de_DE.UTF-8"
-ARG EXTRA_LOCALES=""
-
-RUN set -eux; \
-    # Determine default extras if none provided
-    extras="$EXTRA_LOCALES"; \
-    if [ -z "$extras" ]; then \
-      case "$PRESET" in \
-        light)  extras="";; \
-        standard) extras="en_GB.UTF-8 en_CA.UTF-8 fr_CA.UTF-8 de_DE.UTF-8 es_ES.UTF-8 it_IT.UTF-8 pt_BR.UTF-8";; \
-        full)     extras="en_GB.UTF-8 en_CA.UTF-8 fr_CA.UTF-8 de_DE.UTF-8 es_ES.UTF-8 it_IT.UTF-8 pt_BR.UTF-8 nl_NL.UTF-8 sv_SE.UTF-8 da_DK.UTF-8 nb_NO.UTF-8 pl_PL.UTF-8 cs_CZ.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8";; \
-        *)        echo "Unknown PRESET=$PRESET"; exit 1;; \
-      esac; \
-    fi; \
-    # Always enable en_US.UTF-8
-    sed -i 's/^# \?\(en_US\.UTF-8\)/\1/' /etc/locale.gen; \
-    # Enable extras
-    for loc in $extras; do \
-      esc="$(printf '%s\n' "$loc" | sed 's/[.[\*^$]/\\&/g')"; \
-      if ! grep -q "^$esc" /etc/locale.gen; then echo "$loc UTF-8" >> /etc/locale.gen; fi; \
-      sed -i "s/^# \?$esc/$esc/" /etc/locale.gen; \
-    done; \
-    locale-gen
-
-# Keep default process language in English
-ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
-
-
-ARG DUCKDB_VERSION=1.3.2
-ARG TARGETARCH
-
-RUN set -eux; \
-  case "$TARGETARCH" in \
-    amd64) duck_arch='linux-amd64' ;; \
-    arm64) duck_arch='linux-arm64' ;; \
-    *) echo "Unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
-  esac; \
-  curl -fsSL -o /tmp/duckdb_cli.zip \
-    "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-${duck_arch}.zip"; \
-  unzip -q /tmp/duckdb_cli.zip -d /usr/local/bin; \
-  chmod +x /usr/local/bin/duckdb; \
-  rm -f /tmp/duckdb_cli.zip
-
-# Python QoL libs in an isolated venv (PEP 668 friendly)
-RUN set -eux; \
-    python3 -m venv /opt/venv; \
-    /opt/venv/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel; \
-    /opt/venv/bin/pip install --no-cache-dir \
-        requests beautifulsoup4 lxml \
-        numpy pandas pyarrow duckdb \
-        openpyxl python-docx python-pptx \
-        pypdf2 pdfminer.six \
-        jinja2 tqdm
-
-# Make the venv the default Python
-ENV PATH="/opt/venv/bin:${PATH}"
-
-# Alias debian specific names
-RUN set -eux; \
-    ln -sf /usr/bin/batcat /usr/local/bin/bat; \
-    ln -sf /usr/bin/fdfind /usr/local/bin/fd
-
-# Create non-root user and dirs
-RUN set -eux; \
-    groupadd -g "$APP_GID" "$APP_USER"; \
-    useradd -m -u "$APP_UID" -g "$APP_GID" -s /bin/bash "$APP_USER"; \
-    mkdir -p "$WORKSPACE" "$LOG_DIR" /app; \
-    chown -R "$APP_UID:$APP_GID" "$WORKSPACE" "$LOG_DIR" /app
-
-# Copy built server
 COPY --from=builder /out/mcp-server /app/mcp-server
 
-# Reasonable defaults: read-only rootfs + tmpfs are run-time flags (see sample run below)
-USER $APP_USER
-WORKDIR $WORKSPACE
-
-# Healthcheck (lightweight)
-# Replace with a real flag/endpoint from your server if available.
+# Healthcheck matches server endpoints
 HEALTHCHECK --interval=30s --timeout=4s --start-period=10s --retries=3 \
-   CMD curl -fsS "http://127.0.0.1:${PORT}/healthz" >/dev/null \
+  CMD curl -fsS "http://127.0.0.1:${PORT}/healthz" >/dev/null \
     || curl -fsS "http://127.0.0.1:${PORT}/mcp/health" >/dev/null \
     || exit 1
 
-
-EXPOSE ${PORT}
-
-# Logs directory (bind-mount on host for auditing)
-ENV MCP_LOG_DIR=${LOG_DIR}
-  
-# Default entrypoint
-# Adjust flags to match your server (e.g., --addr, --port, --egress, etc.)
 ENTRYPOINT ["/app/mcp-server"]
 CMD ["--transport=http", "--addr=0.0.0.0:3333", "--log-dir=/logs", "--egress=0"]

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,159 @@
+FROM debian:bookworm-slim
+
+# ---- Build-time knobs (choose your preset) ----
+# light  -> smallest, shell + core utils + python basics + poppler + pandoc
+# standard -> adds LibreOffice, ImageMagick, ffmpeg, tesseract, DuckDB, Node.js LTS
+# full     -> standard + TeX subset for high-quality PDF via pandoc/xelatex
+ARG PRESET=standard
+
+# ---- Runtime knobs (can be overridden at run-time) ----
+ENV APP_USER=user \
+    APP_UID=10001 \
+    APP_GID=10001 \
+    APP_HOME=/home/user \
+    WORKSPACE=/workspace \
+    LOG_DIR=/logs \
+    PORT=3333 \
+    LISTEN_ADDR=0.0.0.0 \
+    EGRESS=0 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Base OS setup
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg; \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Package sets (assembled by PRESET) ----
+# Core across all presets
+ENV PKGS_CORE="\
+  bash coreutils findutils grep sed gawk procps psmisc \
+  zip unzip tar gzip xz-utils p7zip-full zstd brotli \
+  ripgrep fd-find jq yq xmlstarlet jo miller python3-csvkit bat \
+  moreutils parallel \
+  file tree \
+  httpie \
+  bind9-dnsutils iputils-ping traceroute netcat-openbsd socat \
+  openssh-client rsync \
+  locales \
+  make cmake pkg-config build-essential \
+  git git-lfs \
+  openssl gpg \
+  poppler-utils pandoc \
+  python3 python3-pip python3-venv python3-distutils \
+  sqlite3"
+
+# Standard extras
+ENV PKGS_STANDARD_EXTRA="\
+  libreoffice \
+  imagemagick \
+  ffmpeg \
+  tesseract-ocr tesseract-ocr-eng \
+  ocrmypdf qpdf pdfgrep ghostscript \
+  fonts-noto fonts-noto-cjk fonts-noto-color-emoji \
+  libimage-exiftool-perl \
+  nodejs"
+
+# Full extras (TeX subset; sizable)
+ENV PKGS_FULL_EXTRA="\
+  texlive-xetex"
+
+# Node 22.x LTS (only if standard/full chosen)
+RUN set -eux; \
+    if [ "$PRESET" != "light" ]; then \
+      curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
+      apt-get update; \
+    fi
+
+# Optional extra OCR languages (space-separated apt package names)
+ARG TESS_LANGS_EXTRA=""
+
+# Install packages based on PRESET (with preset-aware OCR defaults)
+RUN set -eux; \
+    apt-get update; \
+    case "$PRESET" in \
+      light)  tess_extra="${TESS_LANGS_EXTRA:-}";; \
+      standard) tess_extra="${TESS_LANGS_EXTRA:-"tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa tesseract-ocr-ita tesseract-ocr-por"}";; \
+      full)     tess_extra="${TESS_LANGS_EXTRA:-"tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa tesseract-ocr-ita tesseract-ocr-por tesseract-ocr-nld tesseract-ocr-swe tesseract-ocr-dan tesseract-ocr-nor tesseract-ocr-pol tesseract-ocr-ces tesseract-ocr-rus tesseract-ocr-chi-sim tesseract-ocr-chi-tra tesseract-ocr-jpn tesseract-ocr-kor"}";; \
+      *)        echo "Unknown PRESET=$PRESET"; exit 1 ;; \
+    esac; \
+    case "$PRESET" in \
+      light)  apt-get install -y --no-install-recommends $PKGS_CORE ;; \
+      standard) apt-get install -y --no-install-recommends $PKGS_CORE $PKGS_STANDARD_EXTRA $tess_extra ;; \
+      full)     apt-get install -y --no-install-recommends $PKGS_CORE $PKGS_STANDARD_EXTRA $PKGS_FULL_EXTRA $tess_extra ;; \
+    esac; \
+    apt-get autoremove -y; \
+    rm -rf /var/lib/apt/lists/*
+
+# ----- Locales (always English; optional extras) -----
+# EXTRA_LOCALES: space-separated list like "fr_CA.UTF-8 de_DE.UTF-8"
+ARG EXTRA_LOCALES=""
+
+RUN set -eux; \
+    extras="$EXTRA_LOCALES"; \
+    if [ -z "$extras" ]; then \
+      case "$PRESET" in \
+        light)  extras="";; \
+        standard) extras="en_GB.UTF-8 en_CA.UTF-8 fr_CA.UTF-8 de_DE.UTF-8 es_ES.UTF-8 it_IT.UTF-8 pt_BR.UTF-8";; \
+        full)     extras="en_GB.UTF-8 en_CA.UTF-8 fr_CA.UTF-8 de_DE.UTF-8 es_ES.UTF-8 it_IT.UTF-8 pt_BR.UTF-8 nl_NL.UTF-8 sv_SE.UTF-8 da_DK.UTF-8 nb_NO.UTF-8 pl_PL.UTF-8 cs_CZ.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8";; \
+        *)        echo "Unknown PRESET=$PRESET"; exit 1;; \
+      esac; \
+    fi; \
+    sed -i 's/^# \?\(en_US\.UTF-8\)/\1/' /etc/locale.gen; \
+    for loc in $extras; do \
+      esc="$(printf '%s\n' "$loc" | sed 's/[.[\*^$]/\\&/g')"; \
+      if ! grep -q "^$esc" /etc/locale.gen; then echo "$loc UTF-8" >> /etc/locale.gen; fi; \
+      sed -i "s/^# \?$esc/$esc/" /etc/locale.gen; \
+    done; \
+    locale-gen
+
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+ARG DUCKDB_VERSION=1.3.2
+ARG TARGETARCH
+
+RUN set -eux; \
+  case "$TARGETARCH" in \
+    amd64) duck_arch='linux-amd64' ;; \
+    arm64) duck_arch='linux-arm64' ;; \
+    *) echo "Unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL -o /tmp/duckdb_cli.zip \
+    "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-${duck_arch}.zip"; \
+  unzip -q /tmp/duckdb_cli.zip -d /usr/local/bin; \
+  chmod +x /usr/local/bin/duckdb; \
+  rm -f /tmp/duckdb_cli.zip
+
+# Python QoL libs in an isolated venv (PEP 668 friendly)
+RUN set -eux; \
+    python3 -m venv /opt/venv; \
+    /opt/venv/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel; \
+    /opt/venv/bin/pip install --no-cache-dir \
+        requests beautifulsoup4 lxml \
+        numpy pandas pyarrow duckdb \
+        openpyxl python-docx python-pptx \
+        pypdf2 pdfminer.six \
+        jinja2 tqdm
+
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Alias debian specific names
+RUN set -eux; \
+    ln -sf /usr/bin/batcat /usr/local/bin/bat; \
+    ln -sf /usr/bin/fdfind /usr/local/bin/fd
+
+# Create non-root user and dirs
+RUN set -eux; \
+    groupadd -g "$APP_GID" "$APP_USER"; \
+    useradd -m -u "$APP_UID" -g "$APP_GID" -s /bin/bash "$APP_USER"; \
+    mkdir -p "$WORKSPACE" "$LOG_DIR" /app; \
+    chown -R "$APP_UID:$APP_GID" "$WORKSPACE" "$LOG_DIR" /app
+
+USER $APP_USER
+WORKDIR $WORKSPACE
+
+ENV MCP_LOG_DIR=${LOG_DIR}
+EXPOSE ${PORT}
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -21,29 +21,42 @@
 
 ## Build
 
-Choose one of three presets; optional language packs and locales are parameterized.
+Tool layers are prebuilt and published with a `tools-` tag prefix. The main
+Dockerfile simply adds the compiled server on top of one of these layers:
 
 ```bash
-# Minimal (smallest: shell + core utils + python basics + poppler + pandoc)
-docker build -t mcp-shell:mini --build-arg PRESET=minimal .
+# Standard image using the latest tool layer
+docker build -t mcp-shell:std \
+  --build-arg BASE_IMAGE=ghcr.io/<owner>/mcp-shell:tools-std-latest .
 
-# Standard (recommended: adds LibreOffice, ImageMagick, ffmpeg, Tesseract, DuckDB, Node.js LTS)
-docker build -t mcp-shell:std  --build-arg PRESET=standard .
+# Light image
+docker build -t mcp-shell:mini \
+  --build-arg BASE_IMAGE=ghcr.io/<owner>/mcp-shell:tools-light-latest .
 
-# Full (adds TeX subset for high-quality PDF output; larger image)
-docker build -t mcp-shell:full --build-arg PRESET=full .
+# Full image
+docker build -t mcp-shell:full \
+  --build-arg BASE_IMAGE=ghcr.io/<owner>/mcp-shell:tools-full-latest .
 ```
 
-Optional (only meaningful for `standard`/`full`):
+To rebuild the underlying tool layer itself (usually only needed when the
+tooling changes), use `Dockerfile.tools`:
+
+```bash
+docker build -f Dockerfile.tools -t ghcr.io/<owner>/mcp-shell:tools-std \
+  --build-arg PRESET=standard .
+```
+
+Optional OCR languages or locales (meaningful for `standard`/`full`) apply when
+building the tool layer:
 
 ```bash
 # Extra OCR languages (English `eng` is always installed)
-docker build -t mcp-shell:std \
+docker build -f Dockerfile.tools -t ghcr.io/<owner>/mcp-shell:tools-std \
   --build-arg PRESET=standard \
   --build-arg TESS_LANGS_EXTRA="tesseract-ocr-fra tesseract-ocr-deu" .
 
 # Extra locales (English en_US.UTF-8 is always enabled)
-docker build -t mcp-shell:std \
+docker build -f Dockerfile.tools -t ghcr.io/<owner>/mcp-shell:tools-std \
   --build-arg PRESET=standard \
   --build-arg EXTRA_LOCALES="fr_CA.UTF-8 de_DE.UTF-8" .
 ```


### PR DESCRIPTION
## Summary
- build heavyweight tool layers only when tagging a release
- reuse latest published tool layers during CI and copy in new server binary
- document new build process and split Dockerfiles for tools vs runtime

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6d5e56ae8832ca621eef030a52d1a