### PR TITLE
docs: document filesystem tools

### DIFF
--- a/doc/functions.md
+++ b/doc/functions.md
@@ -8,4 +8,12 @@ List of functions exposed by `mcp-shell`.
 | `GET /readyz` | none | `{status:"ok", name, version, uptime}` | Readiness probe |
 | `GET /mcp/health` | none | `{status:"ok", name, version, uptime}` | MCP-native health endpoint |
 | `shell.exec` | `cmd` (string, required), `cwd?`, `env?`, `timeout_ms?`, `stdin?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Execute a shell command in the container |
-
+| `fs.list` | `path` (string), `glob?`, `include_hidden?`, `max_entries?` | `{entries:[{name,type,size,mtime,mode}], duration_ms, error?}` | List directory entries |
+| `fs.stat` | `path` (string) | `{type,size,mode,mtime,uid,gid,symlink_target?,duration_ms,error?}` | File or directory metadata |
+| `fs.read` | `path` (string), `max_bytes?`, `start_offset?` | `{content, truncated, duration_ms, error?}` | Read UTF-8 text file |
+| `fs.read_b64` | `path` (string), `max_bytes?`, `start_offset?` | `{content_b64, truncated, duration_ms, error?}` | Read file as base64 |
+| `fs.write` | `path`, `content?`, `content_b64?`, `mode?`, `create_parents?`, `append?`, `dry_run?` | `{bytes_written, duration_ms, error?}` | Write a file |
+| `fs.remove` | `path`, `recursive?` | `{removed, duration_ms, error?}` | Remove file or directory |
+| `fs.mkdir` | `path`, `parents?`, `mode?` | `{created, duration_ms, error?}` | Create directory |
+| `fs.move` | `src`, `dest`, `overwrite?`, `parents?` | `{moved, duration_ms, error?}` | Move or rename a file |
+| `fs.copy` | `src`, `dest`, `overwrite?`, `parents?`, `recursive?` | `{copied, duration_ms, error?}` | Copy a file or directory |


### PR DESCRIPTION
## Summary
- document all fs.* tools in doc/functions.md

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6d732b32c832cbd7e5b64df066bcd