### PR TITLE
Add search, diff, and patch utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec` (run a shell command) and `fs.*` (list, stat, read, write, and other basic filesystem ops).
+- **Primary tools**: `shell.exec`, `fs.*` (list, stat, read, write, search, etc.), and text utilities like `text.diff` and `text.apply_patch`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.
 - **Security model**: Execution is confined to a non-root user in a container. You control:
   - Host mounts (read-only vs read-write).

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -17,3 +17,6 @@ List of functions exposed by `mcp-shell`.
 | `fs.mkdir` | `path`, `parents?`, `mode?` | `{created, duration_ms, error?}` | Create directory |
 | `fs.move` | `src`, `dest`, `overwrite?`, `parents?` | `{moved, duration_ms, error?}` | Move or rename a file |
 | `fs.copy` | `src`, `dest`, `overwrite?`, `parents?`, `recursive?` | `{copied, duration_ms, error?}` | Copy a file or directory |
+| `fs.search` | `path`, `query`, `regex?`, `glob?`, `case_sensitive?`, `max_results?` | `{matches:[{file,line,byte_offset,preview}], duration_ms, error?}` | Search file contents using ripgrep |
+| `text.diff` | `a`, `b`, `algo?` (`myers`\|`patience`) | `{unified_diff, duration_ms, error?}` | Compute unified diff between two strings |
+| `text.apply_patch` | `path`, `unified_diff`, `dry_run?` | `{patched, hunks_applied, hunks_failed, duration_ms, error?}` | Apply a unified diff patch to a file |

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -91,3 +91,24 @@ func TestReadBinaryFails(t *testing.T) {
 		t.Fatalf("expected utf-8 error")
 	}
 }
+
+func TestSearch(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	if err := os.WriteFile(filepath.Join(ws, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "b.md"), []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cs := false
+	resp := Search(ctx, SearchRequest{Path: ws, Query: "hello", CaseSensitive: &cs})
+	if resp.Error != "" || len(resp.Matches) != 2 {
+		t.Fatalf("search got %+v", resp)
+	}
+	resp = Search(ctx, SearchRequest{Path: ws, Query: "h.*o", Regex: true, Glob: "*.txt"})
+	if resp.Error != "" || len(resp.Matches) != 1 {
+		t.Fatalf("search regex/glob got %+v", resp)
+	}
+}

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -1,0 +1,199 @@
+package text
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const LogPath = "/logs/mcp-shell.log"
+
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func allowOutside() bool {
+	v := os.Getenv("FS_ALLOW_OUTSIDE_WORKSPACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	if allowOutside() {
+		return p, nil
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", errors.New("path escapes workspace")
+	}
+	return p, nil
+}
+
+func audit(rec any) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+// ---- text.diff
+
+type DiffRequest struct {
+	A    string `json:"a"`
+	B    string `json:"b"`
+	Algo string `json:"algo,omitempty"`
+}
+
+type DiffResponse struct {
+	UnifiedDiff string `json:"unified_diff"`
+	DurationMs  int64  `json:"duration_ms"`
+	Error       string `json:"error,omitempty"`
+}
+
+func Diff(ctx context.Context, in DiffRequest) DiffResponse {
+	start := time.Now()
+	dir, err := os.MkdirTemp("", "diff")
+	if err != nil {
+		return DiffResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer os.RemoveAll(dir)
+	aPath := filepath.Join(dir, "a.txt")
+	bPath := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(aPath, []byte(in.A), 0o644); err != nil {
+		return DiffResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if err := os.WriteFile(bPath, []byte(in.B), 0o644); err != nil {
+		return DiffResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	args := []string{"diff", "--no-index", "--unified=3"}
+	switch strings.ToLower(in.Algo) {
+	case "patience":
+		args = append(args, "--patience")
+	case "myers", "":
+		// default algorithm is myers; no flag needed
+	default:
+		// unrecognized algorithm: default to myers
+	}
+	args = append(args, aPath, bPath)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if ee.ExitCode() > 1 {
+				return DiffResponse{DurationMs: time.Since(start).Milliseconds(), Error: stderr.String()}
+			}
+			// exit code 1 means diff exists; treat as success
+		} else {
+			return DiffResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+	}
+	resp := DiffResponse{UnifiedDiff: stdout.String()}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Algo       string `json:"algo"`
+		DurationMs int64  `json:"duration_ms"`
+		BytesOut   int    `json:"bytes_out"`
+	}{time.Now().UTC().Format(time.RFC3339), "text.diff", in.Algo, resp.DurationMs, len(resp.UnifiedDiff)})
+	return resp
+}
+
+// ---- text.apply_patch
+
+type ApplyPatchRequest struct {
+	Path        string `json:"path"`
+	UnifiedDiff string `json:"unified_diff"`
+	DryRun      bool   `json:"dry_run,omitempty"`
+}
+
+type ApplyPatchResponse struct {
+	Patched      bool   `json:"patched"`
+	HunksApplied int    `json:"hunks_applied"`
+	HunksFailed  int    `json:"hunks_failed"`
+	DurationMs   int64  `json:"duration_ms"`
+	Error        string `json:"error,omitempty"`
+}
+
+func ApplyPatch(ctx context.Context, in ApplyPatchRequest) ApplyPatchResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return ApplyPatchResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	tmp, err := os.CreateTemp("", "patch")
+	if err != nil {
+		return ApplyPatchResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if _, err := tmp.WriteString(in.UnifiedDiff); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return ApplyPatchResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	args := []string{"--batch", "--verbose"}
+	if in.DryRun {
+		args = append(args, "--dry-run")
+	}
+	args = append(args, path, tmp.Name())
+	cmd := exec.CommandContext(ctx, "patch", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
+	output := out.String()
+	applied := strings.Count(output, "succeeded at")
+	failed := strings.Count(output, "FAILED")
+	resp := ApplyPatchResponse{
+		Patched:      err == nil && failed == 0,
+		HunksApplied: applied,
+		HunksFailed:  failed,
+	}
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 && failed > 0 {
+			// hunk failures reported separately
+		} else {
+			resp.Error = output
+		}
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS           string `json:"ts"`
+		Tool         string `json:"tool"`
+		Path         string `json:"path"`
+		DurationMs   int64  `json:"duration_ms"`
+		PatchBytes   int    `json:"patch_bytes"`
+		HunksApplied int    `json:"hunks_applied"`
+		HunksFailed  int    `json:"hunks_failed"`
+		DryRun       bool   `json:"dry_run,omitempty"`
+	}{time.Now().UTC().Format(time.RFC3339), "text.apply_patch", path, resp.DurationMs, len(in.UnifiedDiff), resp.HunksApplied, resp.HunksFailed, in.DryRun})
+	return resp
+}

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -1,0 +1,32 @@
+package text
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiffAndPatch(t *testing.T) {
+	ctx := context.Background()
+	a := "line1\nline2\n"
+	b := "line1_changed\nline2\n"
+	d := Diff(ctx, DiffRequest{A: a, B: b})
+	if d.Error != "" || d.UnifiedDiff == "" {
+		t.Fatalf("diff resp %+v", d)
+	}
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	path := filepath.Join(ws, "file.txt")
+	if err := os.WriteFile(path, []byte(a), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := ApplyPatch(ctx, ApplyPatchRequest{Path: path, UnifiedDiff: d.UnifiedDiff})
+	if p.Error != "" || !p.Patched || p.HunksFailed != 0 {
+		t.Fatalf("patch resp %+v", p)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != b {
+		t.Fatalf("patched content %q", data)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gaspardpetit/mcp-shell/internal/fs"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
+	"github.com/gaspardpetit/mcp-shell/internal/text"
 )
 
 var (
@@ -161,6 +162,42 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "fs.copy result"), nil
 	})
 	s.AddTool(fsCopyTool, fsCopyHandler)
+
+	// fs.search
+	fsSearchTool := mcp.NewTool(
+		"fs.search",
+		mcp.WithDescription("Search for text in files"),
+		mcp.WithInputSchema[fs.SearchRequest](),
+	)
+	fsSearchHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.SearchRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Search(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.search result"), nil
+	})
+	s.AddTool(fsSearchTool, fsSearchHandler)
+
+	// text.diff
+	textDiffTool := mcp.NewTool(
+		"text.diff",
+		mcp.WithDescription("Compute a unified diff between two strings"),
+		mcp.WithInputSchema[text.DiffRequest](),
+	)
+	textDiffHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args text.DiffRequest) (*mcp.CallToolResult, error) {
+		resp := text.Diff(ctx, args)
+		return mcp.NewToolResultStructured(resp, "text.diff result"), nil
+	})
+	s.AddTool(textDiffTool, textDiffHandler)
+
+	// text.apply_patch
+	textPatchTool := mcp.NewTool(
+		"text.apply_patch",
+		mcp.WithDescription("Apply a unified diff patch to a file"),
+		mcp.WithInputSchema[text.ApplyPatchRequest](),
+	)
+	textPatchHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args text.ApplyPatchRequest) (*mcp.CallToolResult, error) {
+		resp := text.ApplyPatch(ctx, args)
+		return mcp.NewToolResultStructured(resp, "text.apply_patch result"), nil
+	})
+	s.AddTool(textPatchTool, textPatchHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add `fs.search` powered by ripgrep
- support `text.diff` and `text.apply_patch` tools
- document new tools and expand README

## Testing
- `make fmt`
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a71a2a2028832cb3e56e283e74503d