### PR TITLE
Add archive and hashing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec`, `fs.*` (list, stat, read, write, search, etc.), and text utilities like `text.diff` and `text.apply_patch`.
+- **Primary tools**: `shell.exec`, `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, and text utilities like `text.diff` and `text.apply_patch`.
 - **Dependencies**: `fs.search` relies on the `rg` binary (ripgrep); install it to enable content search.
   Development dependencies are listed in `scripts/deps.txt` and can be installed via `scripts/install-deps.sh`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -18,5 +18,10 @@ List of functions exposed by `mcp-shell`.
 | `fs.move` | `src`, `dest`, `overwrite?`, `parents?` | `{moved, duration_ms, error?}` | Move or rename a file |
 | `fs.copy` | `src`, `dest`, `overwrite?`, `parents?`, `recursive?` | `{copied, duration_ms, error?}` | Copy a file or directory |
 | `fs.search` | `path`, `query`, `regex?`, `glob?`, `case_sensitive?`, `max_results?` | `{matches:[{file,line,byte_offset,preview}], duration_ms, error?}` | Search file contents using ripgrep (requires `rg`) |
+| `fs.hash` | `path`, `algo` (`sha256`\|`sha1`\|`md5`) | `{hash, duration_ms, error?}` | Compute a file checksum |
+| `archive.zip` | `src`, `dest`, `include?`, `exclude?` | `{archive_path, files, duration_ms, error?}` | Create a zip archive |
+| `archive.unzip` | `src`, `dest`, `include?`, `exclude?` | `{extracted, files, duration_ms, error?}` | Extract a zip archive |
+| `archive.tar` | `src`, `dest`, `include?`, `exclude?` | `{archive_path, files, duration_ms, error?}` | Create a tar archive |
+| `archive.untar` | `src`, `dest`, `include?`, `exclude?` | `{extracted, files, duration_ms, error?}` | Extract a tar archive |
 | `text.diff` | `a`, `b`, `algo?` (`myers`\|`patience`) | `{unified_diff, duration_ms, error?}` | Compute unified diff between two strings |
 | `text.apply_patch` | `path`, `unified_diff`, `dry_run?` | `{patched, hunks_applied, hunks_failed, duration_ms, error?}` | Apply a unified diff patch to a file |

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,0 +1,446 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const LogPath = "/logs/mcp-shell.log"
+
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func allowOutside() bool {
+	v := os.Getenv("FS_ALLOW_OUTSIDE_WORKSPACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	if allowOutside() {
+		return p, nil
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", errors.New("path escapes workspace")
+	}
+	return p, nil
+}
+
+func audit(rec any) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+func shouldInclude(name string, include, exclude []string) bool {
+	for _, ex := range exclude {
+		if ok, _ := filepath.Match(ex, name); ok {
+			return false
+		}
+	}
+	if len(include) == 0 {
+		return true
+	}
+	for _, in := range include {
+		if ok, _ := filepath.Match(in, name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- archive.zip
+
+type ZipRequest struct {
+	Src     string   `json:"src"`
+	Dest    string   `json:"dest"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+type ZipResponse struct {
+	ArchivePath string `json:"archive_path"`
+	Files       int    `json:"files"`
+	DurationMs  int64  `json:"duration_ms"`
+	Error       string `json:"error,omitempty"`
+}
+
+func Zip(ctx context.Context, in ZipRequest) ZipResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer out.Close()
+	zw := zip.NewWriter(out)
+	var count int
+	err = filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		if !shouldInclude(rel, in.Include, in.Exclude) {
+			return nil
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		hdr.Method = zip.Deflate
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(w, f); err != nil {
+			return err
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		zw.Close()
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if err := zw.Close(); err != nil {
+		return ZipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	resp := ZipResponse{ArchivePath: dest, Files: count}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		Files      int    `json:"files"`
+		DurationMs int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "archive.zip", src, dest, count, resp.DurationMs})
+	return resp
+}
+
+// ---- archive.unzip
+
+type UnzipRequest struct {
+	Src     string   `json:"src"`
+	Dest    string   `json:"dest"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+type UnzipResponse struct {
+	Extracted  bool   `json:"extracted"`
+	Files      int    `json:"files"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Unzip(ctx context.Context, in UnzipRequest) UnzipResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer r.Close()
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	var count int
+	for _, f := range r.File {
+		if !shouldInclude(f.Name, in.Include, in.Exclude) {
+			continue
+		}
+		fp := filepath.Join(dest, f.Name)
+		if !allowOutside() {
+			rel, err := filepath.Rel(workspaceRoot(), fp)
+			if err != nil || strings.HasPrefix(rel, "..") {
+				return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: "path escapes workspace"}
+			}
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(fp, 0o755); err != nil {
+				return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+			return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		out, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		if err != nil {
+			rc.Close()
+			return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return UnzipResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		out.Close()
+		rc.Close()
+		count++
+	}
+	resp := UnzipResponse{Extracted: true, Files: count}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		Files      int    `json:"files"`
+		DurationMs int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "archive.unzip", src, dest, count, resp.DurationMs})
+	return resp
+}
+
+// ---- archive.tar
+
+type TarRequest struct {
+	Src     string   `json:"src"`
+	Dest    string   `json:"dest"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+type TarResponse struct {
+	ArchivePath string `json:"archive_path"`
+	Files       int    `json:"files"`
+	DurationMs  int64  `json:"duration_ms"`
+	Error       string `json:"error,omitempty"`
+}
+
+func Tar(ctx context.Context, in TarRequest) TarResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer out.Close()
+	tw := tar.NewWriter(out)
+	var count int
+	err = filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if !shouldInclude(rel, in.Include, in.Exclude) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			f, err := os.Open(p)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tw, f); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		tw.Close()
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if err := tw.Close(); err != nil {
+		return TarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	resp := TarResponse{ArchivePath: dest, Files: count}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		Files      int    `json:"files"`
+		DurationMs int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "archive.tar", src, dest, count, resp.DurationMs})
+	return resp
+}
+
+// ---- archive.untar
+
+type UntarRequest struct {
+	Src     string   `json:"src"`
+	Dest    string   `json:"dest"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+type UntarResponse struct {
+	Extracted  bool   `json:"extracted"`
+	Files      int    `json:"files"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Untar(ctx context.Context, in UntarRequest) UntarResponse {
+	start := time.Now()
+	src, err := normalizePath(in.Src)
+	if err != nil {
+		return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	dest, err := normalizePath(in.Dest)
+	if err != nil {
+		return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	var count int
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		if !shouldInclude(hdr.Name, in.Include, in.Exclude) {
+			continue
+		}
+		fp := filepath.Join(dest, hdr.Name)
+		if !allowOutside() {
+			rel, err := filepath.Rel(workspaceRoot(), fp)
+			if err != nil || strings.HasPrefix(rel, "..") {
+				return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: "path escapes workspace"}
+			}
+		}
+		if hdr.FileInfo().IsDir() {
+			if err := os.MkdirAll(fp, hdr.FileInfo().Mode()); err != nil {
+				return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+			return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		out, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdr.FileInfo().Mode())
+		if err != nil {
+			return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			return UntarResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		}
+		out.Close()
+		count++
+	}
+	resp := UntarResponse{Extracted: true, Files: count}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		Files      int    `json:"files"`
+		DurationMs int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "archive.untar", src, dest, count, resp.DurationMs})
+	return resp
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,0 +1,62 @@
+package archive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestZipUnzip(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	srcDir := filepath.Join(ws, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "b.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	zipPath := filepath.Join(ws, "out.zip")
+	if resp := Zip(ctx, ZipRequest{Src: srcDir, Dest: zipPath}); resp.Error != "" || resp.Files != 2 {
+		t.Fatalf("zip resp %+v", resp)
+	}
+	destDir := filepath.Join(ws, "unz")
+	if resp := Unzip(ctx, UnzipRequest{Src: zipPath, Dest: destDir}); resp.Error != "" || resp.Files != 2 {
+		t.Fatalf("unzip resp %+v", resp)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "a.txt")); err != nil {
+		t.Fatalf("stat a.txt: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "b.txt")); err != nil {
+		t.Fatalf("stat b.txt: %v", err)
+	}
+}
+
+func TestTarUntar(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	srcDir := filepath.Join(ws, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tarPath := filepath.Join(ws, "out.tar")
+	if resp := Tar(ctx, TarRequest{Src: srcDir, Dest: tarPath}); resp.Error != "" || resp.Files != 1 {
+		t.Fatalf("tar resp %+v", resp)
+	}
+	destDir := filepath.Join(ws, "unt")
+	if resp := Untar(ctx, UntarRequest{Src: tarPath, Dest: destDir}); resp.Error != "" || resp.Files != 1 {
+		t.Fatalf("untar resp %+v", resp)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "a.txt")); err != nil {
+		t.Fatalf("stat a.txt: %v", err)
+	}
+}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -116,3 +116,20 @@ func TestSearch(t *testing.T) {
 		t.Fatalf("search regex/glob got %+v", resp)
 	}
 }
+
+func TestHash(t *testing.T) {
+	ctx := context.Background()
+	ws := t.TempDir()
+	t.Setenv("WORKSPACE", ws)
+	if err := os.WriteFile(filepath.Join(ws, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	resp := Hash(ctx, HashRequest{Path: "file.txt", Algo: "sha256"})
+	expected := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if resp.Error != "" || resp.Hash != expected {
+		t.Fatalf("hash got %+v", resp)
+	}
+	if resp := Hash(ctx, HashRequest{Path: "file.txt", Algo: "foo"}); resp.Error == "" {
+		t.Fatalf("expected error for unsupported algo")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	mcp "github.com/mark3labs/mcp-go/mcp"
 	server "github.com/mark3labs/mcp-go/server"
 
+	"github.com/gaspardpetit/mcp-shell/internal/archive"
 	"github.com/gaspardpetit/mcp-shell/internal/fs"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
 	"github.com/gaspardpetit/mcp-shell/internal/text"
@@ -174,6 +175,66 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "fs.search result"), nil
 	})
 	s.AddTool(fsSearchTool, fsSearchHandler)
+
+	// fs.hash
+	fsHashTool := mcp.NewTool(
+		"fs.hash",
+		mcp.WithDescription("Compute file checksum"),
+		mcp.WithInputSchema[fs.HashRequest](),
+	)
+	fsHashHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args fs.HashRequest) (*mcp.CallToolResult, error) {
+		resp := fs.Hash(ctx, args)
+		return mcp.NewToolResultStructured(resp, "fs.hash result"), nil
+	})
+	s.AddTool(fsHashTool, fsHashHandler)
+
+	// archive.zip
+	archiveZipTool := mcp.NewTool(
+		"archive.zip",
+		mcp.WithDescription("Create a zip archive"),
+		mcp.WithInputSchema[archive.ZipRequest](),
+	)
+	archiveZipHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args archive.ZipRequest) (*mcp.CallToolResult, error) {
+		resp := archive.Zip(ctx, args)
+		return mcp.NewToolResultStructured(resp, "archive.zip result"), nil
+	})
+	s.AddTool(archiveZipTool, archiveZipHandler)
+
+	// archive.unzip
+	archiveUnzipTool := mcp.NewTool(
+		"archive.unzip",
+		mcp.WithDescription("Extract a zip archive"),
+		mcp.WithInputSchema[archive.UnzipRequest](),
+	)
+	archiveUnzipHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args archive.UnzipRequest) (*mcp.CallToolResult, error) {
+		resp := archive.Unzip(ctx, args)
+		return mcp.NewToolResultStructured(resp, "archive.unzip result"), nil
+	})
+	s.AddTool(archiveUnzipTool, archiveUnzipHandler)
+
+	// archive.tar
+	archiveTarTool := mcp.NewTool(
+		"archive.tar",
+		mcp.WithDescription("Create a tar archive"),
+		mcp.WithInputSchema[archive.TarRequest](),
+	)
+	archiveTarHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args archive.TarRequest) (*mcp.CallToolResult, error) {
+		resp := archive.Tar(ctx, args)
+		return mcp.NewToolResultStructured(resp, "archive.tar result"), nil
+	})
+	s.AddTool(archiveTarTool, archiveTarHandler)
+
+	// archive.untar
+	archiveUntarTool := mcp.NewTool(
+		"archive.untar",
+		mcp.WithDescription("Extract a tar archive"),
+		mcp.WithInputSchema[archive.UntarRequest](),
+	)
+	archiveUntarHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args archive.UntarRequest) (*mcp.CallToolResult, error) {
+		resp := archive.Untar(ctx, args)
+		return mcp.NewToolResultStructured(resp, "archive.untar result"), nil
+	})
+	s.AddTool(archiveUntarTool, archiveUntarHandler)
 
 	// text.diff
 	textDiffTool := mcp.NewTool(


### PR DESCRIPTION
## Summary
- implement archive.zip/unzip and archive.tar/untar with include/exclude support
- add fs.hash for file checksums
- document new tools and update overview

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a73f518200832cac894b5224e59222