### PR TITLE
feat: add document and PDF utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec`, `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, and text utilities like `text.diff` and `text.apply_patch`.
+- **Primary tools**: `shell.exec`, `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, and document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, and `doc.metadata`.
 - **Dependencies**: `fs.search` relies on the `rg` binary (ripgrep); install it to enable content search.
   Development dependencies are listed in `scripts/deps.txt` and can be installed via `scripts/install-deps.sh`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -25,3 +25,7 @@ List of functions exposed by `mcp-shell`.
 | `archive.untar` | `src`, `dest`, `include?`, `exclude?` | `{extracted, files, duration_ms, error?}` | Extract a tar archive |
 | `text.diff` | `a`, `b`, `algo?` (`myers`\|`patience`) | `{unified_diff, duration_ms, error?}` | Compute unified diff between two strings |
 | `text.apply_patch` | `path`, `unified_diff`, `dry_run?` | `{patched, hunks_applied, hunks_failed, duration_ms, error?}` | Apply a unified diff patch to a file |
+| `doc.convert` | `src_path`, `dest_format`, `options?` | `{dest_path,size,duration_ms,error?}` | Convert documents via LibreOffice or Pandoc |
+| `pdf.extract_text` | `path`, `layout?` (`raw`\|`layout`\|`html`), `max_bytes?` | `{text,truncated,duration_ms,error?}` | Extract text from a PDF |
+| `spreadsheet.to_csv` | `path`, `sheet?` (name or index), `max_bytes?` | `{csv,truncated,duration_ms,error?}` | Convert a spreadsheet sheet to CSV |
+| `doc.metadata` | `path` | `{mime,pages?,words?,created?,modified?,duration_ms,error?}` | Retrieve document metadata |

--- a/internal/doc/doc.go
+++ b/internal/doc/doc.go
@@ -1,0 +1,338 @@
+package doc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	LogPath         = "/logs/mcp-shell.log"
+	defaultMaxBytes = 1 << 20 // 1 MiB
+)
+
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func allowOutside() bool {
+	v := os.Getenv("FS_ALLOW_OUTSIDE_WORKSPACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	if allowOutside() {
+		return p, nil
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", errors.New("path escapes workspace")
+	}
+	return p, nil
+}
+
+func audit(rec any) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+// ---- doc.convert ----
+
+type ConvertRequest struct {
+	SrcPath    string            `json:"src_path"`
+	DestFormat string            `json:"dest_format"`
+	Options    map[string]string `json:"options,omitempty"`
+}
+
+type ConvertResponse struct {
+	DestPath   string `json:"dest_path"`
+	Size       int64  `json:"size"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Convert(ctx context.Context, in ConvertRequest) ConvertResponse {
+	start := time.Now()
+	src, err := normalizePath(in.SrcPath)
+	if err != nil {
+		return ConvertResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	if in.DestFormat == "" {
+		return ConvertResponse{DurationMs: time.Since(start).Milliseconds(), Error: "dest_format is required"}
+	}
+	destFormat := strings.ToLower(in.DestFormat)
+	dir := filepath.Dir(src)
+	base := strings.TrimSuffix(filepath.Base(src), filepath.Ext(src))
+	dest := filepath.Join(dir, base+"."+destFormat)
+
+	var cmd *exec.Cmd
+	switch destFormat {
+	case "md":
+		cmd = exec.CommandContext(ctx, "pandoc", src, "-o", dest)
+	default:
+		args := []string{"--headless", "--convert-to", destFormat, "--outdir", dir, src}
+		cmd = exec.CommandContext(ctx, "libreoffice", args...)
+	}
+	var stderr bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return ConvertResponse{DurationMs: time.Since(start).Milliseconds(), Error: stderr.String()}
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		return ConvertResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	resp := ConvertResponse{DestPath: dest, Size: info.Size()}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Src        string `json:"src"`
+		Dest       string `json:"dest"`
+		DurationMs int64  `json:"duration_ms"`
+		Size       int64  `json:"size"`
+	}{time.Now().UTC().Format(time.RFC3339), "doc.convert", src, dest, resp.DurationMs, resp.Size})
+	return resp
+}
+
+// ---- pdf.extract_text ----
+
+type PDFExtractRequest struct {
+	Path     string `json:"path"`
+	Layout   string `json:"layout,omitempty"`
+	MaxBytes int64  `json:"max_bytes,omitempty"`
+}
+
+type PDFExtractResponse struct {
+	Text       string `json:"text"`
+	Truncated  bool   `json:"truncated"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func ExtractText(ctx context.Context, in PDFExtractRequest) PDFExtractResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return PDFExtractResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	limit := defaultMaxBytes
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	layout := strings.ToLower(in.Layout)
+	var cmd *exec.Cmd
+	switch layout {
+	case "layout":
+		cmd = exec.CommandContext(ctx, "pdftotext", "-layout", path, "-")
+	case "html":
+		cmd = exec.CommandContext(ctx, "pdftohtml", "-i", "-stdout", "-noframes", path, "-")
+	default:
+		cmd = exec.CommandContext(ctx, "pdftotext", path, "-")
+	}
+	var stdout bytes.Buffer
+	lw := &limitedWriter{buf: &stdout, limit: limit}
+	var stderr bytes.Buffer
+	cmd.Stdout = lw
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return PDFExtractResponse{DurationMs: time.Since(start).Milliseconds(), Error: stderr.String()}
+	}
+	resp := PDFExtractResponse{Text: stdout.String(), Truncated: lw.truncated}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		BytesOut   int    `json:"bytes_out"`
+	}{time.Now().UTC().Format(time.RFC3339), "pdf.extract_text", path, resp.DurationMs, len(resp.Text)})
+	return resp
+}
+
+// ---- spreadsheet.to_csv ----
+
+type ToCSVRequest struct {
+	Path     string          `json:"path"`
+	Sheet    json.RawMessage `json:"sheet,omitempty"`
+	MaxBytes int64           `json:"max_bytes,omitempty"`
+}
+
+type ToCSVResponse struct {
+	Csv        string `json:"csv"`
+	Truncated  bool   `json:"truncated"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func SpreadsheetToCSV(ctx context.Context, in ToCSVRequest) ToCSVResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return ToCSVResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	limit := defaultMaxBytes
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	dir := filepath.Dir(path)
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	dest := filepath.Join(dir, base+".csv")
+	args := []string{"--headless", "--convert-to", "csv", "--outdir", dir}
+	if len(in.Sheet) > 0 {
+		var name string
+		if err := json.Unmarshal(in.Sheet, &name); err == nil {
+			if name != "" {
+				args = append(args, "--calc-sheets", name)
+			}
+		} else {
+			var idx int
+			if err := json.Unmarshal(in.Sheet, &idx); err == nil && idx > 0 {
+				args = append(args, "--calc-sheets", strconv.Itoa(idx))
+			}
+		}
+	}
+	args = append(args, path)
+	cmd := exec.CommandContext(ctx, "libreoffice", args...)
+	var stderr bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return ToCSVResponse{DurationMs: time.Since(start).Milliseconds(), Error: stderr.String()}
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		return ToCSVResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	truncated := false
+	if len(data) > limit {
+		data = data[:limit]
+		truncated = true
+	}
+	resp := ToCSVResponse{Csv: string(data), Truncated: truncated}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string          `json:"ts"`
+		Tool       string          `json:"tool"`
+		Path       string          `json:"path"`
+		DurationMs int64           `json:"duration_ms"`
+		BytesOut   int             `json:"bytes_out"`
+		Sheet      json.RawMessage `json:"sheet,omitempty"`
+	}{time.Now().UTC().Format(time.RFC3339), "spreadsheet.to_csv", path, resp.DurationMs, len(resp.Csv), in.Sheet})
+	return resp
+}
+
+// ---- doc.metadata ----
+
+type MetadataRequest struct {
+	Path string `json:"path"`
+}
+
+type MetadataResponse struct {
+	Mime       string `json:"mime"`
+	Pages      int    `json:"pages,omitempty"`
+	Words      int    `json:"words,omitempty"`
+	Created    string `json:"created,omitempty"`
+	Modified   string `json:"modified,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Metadata(ctx context.Context, in MetadataRequest) MetadataResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return MetadataResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	mimeCmd := exec.CommandContext(ctx, "file", "-b", "--mime-type", path)
+	var mimeOut bytes.Buffer
+	mimeCmd.Stdout = &mimeOut
+	if err := mimeCmd.Run(); err != nil {
+		return MetadataResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	mime := strings.TrimSpace(mimeOut.String())
+	resp := MetadataResponse{Mime: mime}
+	if strings.Contains(mime, "pdf") {
+		infoCmd := exec.CommandContext(ctx, "pdfinfo", path)
+		var infoBuf bytes.Buffer
+		infoCmd.Stdout = &infoBuf
+		if err := infoCmd.Run(); err == nil {
+			for _, line := range strings.Split(infoBuf.String(), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "Pages:") {
+					fmt.Sscanf(line, "Pages: %d", &resp.Pages)
+				} else if strings.HasPrefix(line, "CreationDate:") {
+					resp.Created = strings.TrimSpace(strings.TrimPrefix(line, "CreationDate:"))
+				} else if strings.HasPrefix(line, "ModDate:") {
+					resp.Modified = strings.TrimSpace(strings.TrimPrefix(line, "ModDate:"))
+				}
+			}
+		}
+		txtCmd := exec.CommandContext(ctx, "pdftotext", path, "-")
+		var txtBuf bytes.Buffer
+		txtCmd.Stdout = &txtBuf
+		_ = txtCmd.Run()
+		resp.Words = len(strings.Fields(txtBuf.String()))
+	}
+	resp.DurationMs = time.Since(start).Milliseconds()
+	audit(struct {
+		TS         string `json:"ts"`
+		Tool       string `json:"tool"`
+		Path       string `json:"path"`
+		DurationMs int64  `json:"duration_ms"`
+		Mime       string `json:"mime"`
+	}{time.Now().UTC().Format(time.RFC3339), "doc.metadata", path, resp.DurationMs, resp.Mime})
+	return resp
+}
+
+type limitedWriter struct {
+	buf       *bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		return w.buf.Write(p)
+	}
+	if len(p) <= w.limit-w.buf.Len() {
+		return w.buf.Write(p)
+	}
+	need := w.limit - w.buf.Len()
+	if need > 0 {
+		w.buf.Write(p[:need])
+	}
+	w.truncated = true
+	return len(p), nil
+}

--- a/internal/doc/doc_test.go
+++ b/internal/doc/doc_test.go
@@ -1,0 +1,80 @@
+package doc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConvertAndMetadataAndExtract(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	docx := filepath.Join(dir, "sample.docx")
+	cmd := exec.Command("pandoc", "-o", docx)
+	cmd.Stdin = strings.NewReader("Hello world\n")
+	if err := cmd.Run(); err != nil {
+		t.Skip("pandoc not available", err)
+	}
+	pdfResp := Convert(ctx, ConvertRequest{SrcPath: docx, DestFormat: "pdf"})
+	if pdfResp.Error != "" {
+		t.Fatalf("convert to pdf: %v", pdfResp.Error)
+	}
+	if _, err := os.Stat(pdfResp.DestPath); err != nil {
+		t.Fatalf("pdf not created: %v", err)
+	}
+	backResp := Convert(ctx, ConvertRequest{SrcPath: pdfResp.DestPath, DestFormat: "docx"})
+	if backResp.Error != "" {
+		t.Fatalf("convert back to docx: %v", backResp.Error)
+	}
+	if _, err := os.Stat(backResp.DestPath); err != nil {
+		t.Fatalf("docx not created: %v", err)
+	}
+	ext := ExtractText(ctx, PDFExtractRequest{Path: pdfResp.DestPath})
+	if ext.Error != "" {
+		t.Fatalf("extract text: %v", ext.Error)
+	}
+	if !strings.Contains(ext.Text, "Hello world") {
+		t.Fatalf("unexpected text: %q", ext.Text)
+	}
+	meta := Metadata(ctx, MetadataRequest{Path: pdfResp.DestPath})
+	if meta.Error != "" {
+		t.Fatalf("metadata: %v", meta.Error)
+	}
+	if meta.Mime != "application/pdf" {
+		t.Fatalf("unexpected mime: %s", meta.Mime)
+	}
+	if meta.Pages < 1 {
+		t.Fatalf("expected pages >=1, got %d", meta.Pages)
+	}
+}
+
+func TestSpreadsheetToCSV(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	xlsx := filepath.Join(dir, "wb.xlsx")
+	script := fmt.Sprintf(`import openpyxl\nwb=openpyxl.Workbook()\nws1=wb.active\nws1.title='Sheet1'\nws1.append(['A','B'])\nws2=wb.create_sheet('Data')\nws2.append(['C','D'])\nwb.save('%s')\n`, xlsx)
+	if err := exec.Command("python3", "-c", script).Run(); err != nil {
+		t.Skip("python or openpyxl missing", err)
+	}
+	// by name
+	respName := SpreadsheetToCSV(ctx, ToCSVRequest{Path: xlsx, Sheet: json.RawMessage(`"Data"`)})
+	if respName.Error != "" {
+		t.Fatalf("to_csv name: %v", respName.Error)
+	}
+	if !strings.Contains(respName.Csv, "C,D") {
+		t.Fatalf("expected Data sheet, got %q", respName.Csv)
+	}
+	// by index (1-based)
+	respIdx := SpreadsheetToCSV(ctx, ToCSVRequest{Path: xlsx, Sheet: json.RawMessage("1")})
+	if respIdx.Error != "" {
+		t.Fatalf("to_csv index: %v", respIdx.Error)
+	}
+	if !strings.Contains(respIdx.Csv, "A,B") {
+		t.Fatalf("expected first sheet, got %q", respIdx.Csv)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	server "github.com/mark3labs/mcp-go/server"
 
 	"github.com/gaspardpetit/mcp-shell/internal/archive"
+	"github.com/gaspardpetit/mcp-shell/internal/doc"
 	"github.com/gaspardpetit/mcp-shell/internal/fs"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
 	"github.com/gaspardpetit/mcp-shell/internal/text"
@@ -259,6 +260,54 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "text.apply_patch result"), nil
 	})
 	s.AddTool(textPatchTool, textPatchHandler)
+
+	// doc.convert
+	docConvertTool := mcp.NewTool(
+		"doc.convert",
+		mcp.WithDescription("Convert documents between formats"),
+		mcp.WithInputSchema[doc.ConvertRequest](),
+	)
+	docConvertHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args doc.ConvertRequest) (*mcp.CallToolResult, error) {
+		resp := doc.Convert(ctx, args)
+		return mcp.NewToolResultStructured(resp, "doc.convert result"), nil
+	})
+	s.AddTool(docConvertTool, docConvertHandler)
+
+	// pdf.extract_text
+	pdfExtractTool := mcp.NewTool(
+		"pdf.extract_text",
+		mcp.WithDescription("Extract text from a PDF file"),
+		mcp.WithInputSchema[doc.PDFExtractRequest](),
+	)
+	pdfExtractHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args doc.PDFExtractRequest) (*mcp.CallToolResult, error) {
+		resp := doc.ExtractText(ctx, args)
+		return mcp.NewToolResultStructured(resp, "pdf.extract_text result"), nil
+	})
+	s.AddTool(pdfExtractTool, pdfExtractHandler)
+
+	// spreadsheet.to_csv
+	sheetCSVTool := mcp.NewTool(
+		"spreadsheet.to_csv",
+		mcp.WithDescription("Convert a spreadsheet sheet to CSV"),
+		mcp.WithInputSchema[doc.ToCSVRequest](),
+	)
+	sheetCSVHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args doc.ToCSVRequest) (*mcp.CallToolResult, error) {
+		resp := doc.SpreadsheetToCSV(ctx, args)
+		return mcp.NewToolResultStructured(resp, "spreadsheet.to_csv result"), nil
+	})
+	s.AddTool(sheetCSVTool, sheetCSVHandler)
+
+	// doc.metadata
+	docMetaTool := mcp.NewTool(
+		"doc.metadata",
+		mcp.WithDescription("Retrieve document metadata"),
+		mcp.WithInputSchema[doc.MetadataRequest](),
+	)
+	docMetaHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args doc.MetadataRequest) (*mcp.CallToolResult, error) {
+		resp := doc.Metadata(ctx, args)
+		return mcp.NewToolResultStructured(resp, "doc.metadata result"), nil
+	})
+	s.AddTool(docMetaTool, docMetaHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, and `doc.metadata` tools
- document new tools and update README

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a741d581ac832c8bfe2bf14b071726