### PR TITLE
Add Git tooling utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, and document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, and `doc.metadata`.
+- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `git.*` (clone, status, commit, pull, push, etc.), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, and document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, and `doc.metadata`.
 - **Dependencies**: `fs.search` relies on the `rg` binary (ripgrep); install it to enable content search.
   Development dependencies are listed in `scripts/deps.txt` and can be installed via `scripts/install-deps.sh`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -35,3 +35,12 @@ List of functions exposed by `mcp-shell`.
 | `pdf.extract_text` | `path`, `layout?` (`raw`\|`layout`\|`html`), `max_bytes?` | `{text,truncated,duration_ms,error?}` | Extract text from a PDF |
 | `spreadsheet.to_csv` | `path`, `sheet?` (name or index), `max_bytes?` | `{csv,truncated,duration_ms,error?}` | Convert a spreadsheet sheet to CSV |
 | `doc.metadata` | `path` | `{mime,pages?,words?,created?,modified?,duration_ms,error?}` | Retrieve document metadata |
+| `git.clone` | `repo` (string, required), `dir?`, `depth?`, `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Clone a git repository |
+| `git.status` | `path` (string, required), `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Git status (porcelain) |
+| `git.commit` | `path` (string, required), `message` (string, required), `all?`, `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, commit?, error?}` | Commit changes |
+| `git.pull` | `path` (string, required), `rebase?`, `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Pull latest changes |
+| `git.push` | `path` (string, required), `remote?`, `branch?`, `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Push commits (requires `GIT_ALLOW_PUSH=1`) |
+| `git.checkout` | `path` (string, required), `ref` (string, required), `create?`, `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Checkout a git ref |
+| `git.branch` | `path` (string, required), `name?`, `delete?`, `list?`, `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, branches?, error?}` | Manage branches |
+| `git.tag` | `path` (string, required), `name?`, `delete?`, `list?`, `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, tags?, error?}` | Manage tags |
+| `git.lfs.install` | `path` (string, required), `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Install Git LFS in a repository |

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,715 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	DefaultTimeout = 60 * time.Second
+	DefaultMaxIO   = 1 << 20
+	LogPath        = "/logs/mcp-shell.log"
+)
+
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path %q escapes workspace", p)
+	}
+	return p, nil
+}
+
+func egressAllowed() bool {
+	return os.Getenv("EGRESS") == "1"
+}
+
+func pushAllowed() bool {
+	return os.Getenv("GIT_ALLOW_PUSH") == "1"
+}
+
+type limitedWriter struct {
+	buf       *bytes.Buffer
+	limit     int
+	truncated *bool
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		return w.buf.Write(p)
+	}
+	remain := w.limit - w.buf.Len()
+	if remain <= 0 {
+		*w.truncated = true
+		return len(p), nil
+	}
+	if len(p) <= remain {
+		return w.buf.Write(p)
+	}
+	_, _ = w.buf.Write(p[:remain])
+	*w.truncated = true
+	return len(p), nil
+}
+
+func run(ctx context.Context, cwd string, args []string, timeout time.Duration, limit int) (stdout, stderr string, exit int, durationMs int64, stdoutTrunc, stderrTrunc bool) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &limitedWriter{buf: &stdoutBuf, limit: limit, truncated: &stdoutTrunc}
+	cmd.Stderr = &limitedWriter{buf: &stderrBuf, limit: limit, truncated: &stderrTrunc}
+	err := cmd.Run()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+			exit = 124
+		} else {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				exit = ee.ExitCode()
+			} else {
+				exit = 1
+			}
+		}
+	}
+	durationMs = time.Since(start).Milliseconds()
+	stdout = stdoutBuf.String()
+	stderr = stderrBuf.String()
+	return
+}
+
+func audit(tool, path string, args []string, exit int, durationMs int64, bytesOut int, stdoutTrunc, stderrTrunc bool) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	rec := struct {
+		TS              string   `json:"ts"`
+		Tool            string   `json:"tool"`
+		Path            string   `json:"path"`
+		Args            []string `json:"args"`
+		Exit            int      `json:"exit"`
+		DurationMs      int64    `json:"duration_ms"`
+		BytesOut        int      `json:"bytes_out"`
+		StdoutTruncated bool     `json:"stdout_truncated"`
+		StderrTruncated bool     `json:"stderr_truncated"`
+	}{
+		time.Now().UTC().Format(time.RFC3339),
+		tool,
+		path,
+		args,
+		exit,
+		durationMs,
+		bytesOut,
+		stdoutTrunc,
+		stderrTrunc,
+	}
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+// ---- git.clone ----
+
+type CloneRequest struct {
+	Repo      string `json:"repo"`
+	Dir       string `json:"dir,omitempty"`
+	Depth     int    `json:"depth,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+type CloneResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Clone(ctx context.Context, in CloneRequest) CloneResponse {
+	start := time.Now()
+	if in.Repo == "" {
+		return CloneResponse{ExitCode: 1, Error: "repo is required"}
+	}
+	if !egressAllowed() && !in.DryRun {
+		return CloneResponse{ExitCode: 1, Error: "git clone requires egress"}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	cwd := workspaceRoot()
+	args := []string{"clone"}
+	if in.Depth > 0 {
+		args = append(args, fmt.Sprintf("--depth=%d", in.Depth))
+	}
+	args = append(args, in.Repo)
+	if in.Dir != "" {
+		args = append(args, in.Dir)
+	}
+	if in.DryRun {
+		resp := CloneResponse{Stdout: fmt.Sprintf("[dry_run] git %s", strings.Join(args, " ")), ExitCode: 0, DurationMs: time.Since(start).Milliseconds()}
+		audit("git.clone", cwd, args, resp.ExitCode, resp.DurationMs, len(resp.Stdout)+len(resp.Stderr), false, false)
+		return resp
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, cwd, args, timeout, limit)
+	resp := CloneResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git clone failed"
+	}
+	audit("git.clone", cwd, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.status ----
+
+type StatusRequest struct {
+	Path      string `json:"path"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+}
+
+type StatusResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Status(ctx context.Context, in StatusRequest) StatusResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return StatusResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"status", "--porcelain"}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := StatusResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git status failed"
+	}
+	audit("git.status", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.commit ----
+
+type CommitRequest struct {
+	Path      string `json:"path"`
+	Message   string `json:"message"`
+	All       bool   `json:"all,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+type CommitResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Commit          string `json:"commit,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Commit(ctx context.Context, in CommitRequest) CommitResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return CommitResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	if in.Message == "" {
+		return CommitResponse{ExitCode: 1, Error: "message is required", DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"commit", "-m", in.Message}
+	if in.All {
+		args = append(args, "-a")
+	}
+	if in.DryRun {
+		resp := CommitResponse{Stdout: fmt.Sprintf("[dry_run] git %s", strings.Join(args, " ")), ExitCode: 0, DurationMs: time.Since(start).Milliseconds()}
+		audit("git.commit", path, args, resp.ExitCode, resp.DurationMs, len(resp.Stdout)+len(resp.Stderr), false, false)
+		return resp
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := CommitResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit == 0 {
+		revArgs := []string{"rev-parse", "HEAD"}
+		revStdout, _, _, _, _, _ := run(ctx, path, revArgs, timeout, limit)
+		resp.Commit = strings.TrimSpace(revStdout)
+	} else {
+		resp.Error = "git commit failed"
+	}
+	audit("git.commit", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.pull ----
+
+type PullRequest struct {
+	Path      string `json:"path"`
+	Rebase    bool   `json:"rebase,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+type PullResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Pull(ctx context.Context, in PullRequest) PullResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return PullResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	if !egressAllowed() && !in.DryRun {
+		return PullResponse{ExitCode: 1, Error: "git pull requires egress"}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"pull"}
+	if in.Rebase {
+		args = append(args, "--rebase")
+	}
+	if in.DryRun {
+		resp := PullResponse{Stdout: fmt.Sprintf("[dry_run] git %s", strings.Join(args, " ")), ExitCode: 0, DurationMs: time.Since(start).Milliseconds()}
+		audit("git.pull", path, args, resp.ExitCode, resp.DurationMs, len(resp.Stdout)+len(resp.Stderr), false, false)
+		return resp
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := PullResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git pull failed"
+	}
+	audit("git.pull", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.push ----
+
+type PushRequest struct {
+	Path      string `json:"path"`
+	Remote    string `json:"remote,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+type PushResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Push(ctx context.Context, in PushRequest) PushResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return PushResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	if !pushAllowed() && !in.DryRun {
+		return PushResponse{ExitCode: 1, Error: "git push disabled"}
+	}
+	if !egressAllowed() && !in.DryRun {
+		return PushResponse{ExitCode: 1, Error: "git push requires egress"}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"push"}
+	if in.Remote != "" {
+		args = append(args, in.Remote)
+	}
+	if in.Branch != "" {
+		args = append(args, in.Branch)
+	}
+	if in.DryRun {
+		resp := PushResponse{Stdout: fmt.Sprintf("[dry_run] git %s", strings.Join(args, " ")), ExitCode: 0, DurationMs: time.Since(start).Milliseconds()}
+		audit("git.push", path, args, resp.ExitCode, resp.DurationMs, len(resp.Stdout)+len(resp.Stderr), false, false)
+		return resp
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := PushResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git push failed"
+	}
+	audit("git.push", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.checkout ----
+
+type CheckoutRequest struct {
+	Path      string `json:"path"`
+	Ref       string `json:"ref"`
+	Create    bool   `json:"create,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+}
+
+type CheckoutResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func Checkout(ctx context.Context, in CheckoutRequest) CheckoutResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return CheckoutResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	if in.Ref == "" {
+		return CheckoutResponse{ExitCode: 1, Error: "ref is required", DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"checkout"}
+	if in.Create {
+		args = append(args, "-b")
+	}
+	args = append(args, in.Ref)
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := CheckoutResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git checkout failed"
+	}
+	audit("git.checkout", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.branch ----
+
+type BranchRequest struct {
+	Path      string `json:"path"`
+	Name      string `json:"name,omitempty"`
+	Delete    bool   `json:"delete,omitempty"`
+	List      bool   `json:"list,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+}
+
+type BranchResponse struct {
+	Stdout          string   `json:"stdout"`
+	Stderr          string   `json:"stderr"`
+	ExitCode        int      `json:"exit_code"`
+	DurationMs      int64    `json:"duration_ms"`
+	StdoutTruncated bool     `json:"stdout_truncated"`
+	StderrTruncated bool     `json:"stderr_truncated"`
+	Branches        []string `json:"branches,omitempty"`
+	Error           string   `json:"error,omitempty"`
+}
+
+func Branch(ctx context.Context, in BranchRequest) BranchResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return BranchResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"branch"}
+	if in.List || in.Name == "" {
+		args = append(args, "--list")
+	} else {
+		if in.Delete {
+			args = append(args, "-d", in.Name)
+		} else {
+			args = append(args, in.Name)
+		}
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := BranchResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if (in.List || in.Name == "") && exit == 0 {
+		lines := strings.Split(stdout, "\n")
+		for _, l := range lines {
+			l = strings.TrimSpace(strings.TrimPrefix(l, "*"))
+			if l != "" {
+				resp.Branches = append(resp.Branches, l)
+			}
+		}
+	}
+	if exit != 0 {
+		resp.Error = "git branch failed"
+	}
+	audit("git.branch", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.tag ----
+
+type TagRequest struct {
+	Path      string `json:"path"`
+	Name      string `json:"name,omitempty"`
+	Delete    bool   `json:"delete,omitempty"`
+	List      bool   `json:"list,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+}
+
+type TagResponse struct {
+	Stdout          string   `json:"stdout"`
+	Stderr          string   `json:"stderr"`
+	ExitCode        int      `json:"exit_code"`
+	DurationMs      int64    `json:"duration_ms"`
+	StdoutTruncated bool     `json:"stdout_truncated"`
+	StderrTruncated bool     `json:"stderr_truncated"`
+	Tags            []string `json:"tags,omitempty"`
+	Error           string   `json:"error,omitempty"`
+}
+
+func Tag(ctx context.Context, in TagRequest) TagResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return TagResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"tag"}
+	if in.List || in.Name == "" {
+		args = append(args, "--list")
+	} else {
+		if in.Delete {
+			args = append(args, "-d", in.Name)
+		} else {
+			args = append(args, in.Name)
+		}
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := TagResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if (in.List || in.Name == "") && exit == 0 {
+		lines := strings.Split(stdout, "\n")
+		for _, l := range lines {
+			l = strings.TrimSpace(l)
+			if l != "" {
+				resp.Tags = append(resp.Tags, l)
+			}
+		}
+	}
+	if exit != 0 {
+		resp.Error = "git tag failed"
+	}
+	audit("git.tag", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}
+
+// ---- git.lfs.install ----
+
+type LFSInstallRequest struct {
+	Path      string `json:"path"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+type LFSInstallResponse struct {
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExitCode        int    `json:"exit_code"`
+	DurationMs      int64  `json:"duration_ms"`
+	StdoutTruncated bool   `json:"stdout_truncated"`
+	StderrTruncated bool   `json:"stderr_truncated"`
+	Error           string `json:"error,omitempty"`
+}
+
+func LFSInstall(ctx context.Context, in LFSInstallRequest) LFSInstallResponse {
+	start := time.Now()
+	path, err := normalizePath(in.Path)
+	if err != nil {
+		return LFSInstallResponse{ExitCode: 1, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxIO
+	if in.MaxBytes > 0 {
+		limit = int(in.MaxBytes)
+	}
+	args := []string{"lfs", "install"}
+	if in.DryRun {
+		resp := LFSInstallResponse{Stdout: fmt.Sprintf("[dry_run] git %s", strings.Join(args, " ")), ExitCode: 0, DurationMs: time.Since(start).Milliseconds()}
+		audit("git.lfs.install", path, args, resp.ExitCode, resp.DurationMs, len(resp.Stdout)+len(resp.Stderr), false, false)
+		return resp
+	}
+	stdout, stderr, exit, dur, outTrunc, errTrunc := run(ctx, path, args, timeout, limit)
+	resp := LFSInstallResponse{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		ExitCode:        exit,
+		DurationMs:      dur,
+		StdoutTruncated: outTrunc,
+		StderrTruncated: errTrunc,
+	}
+	if exit != 0 {
+		resp.Error = "git lfs install failed"
+	}
+	audit("git.lfs.install", path, args, exit, dur, len(stdout)+len(stderr), outTrunc, errTrunc)
+	return resp
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,48 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloneDisabled(t *testing.T) {
+	os.Setenv("EGRESS", "0")
+	resp := Clone(context.Background(), CloneRequest{Repo: "https://example.com/foo.git"})
+	if resp.ExitCode == 0 {
+		t.Fatalf("expected failure when egress disabled")
+	}
+}
+
+func TestStatusAndCommit(t *testing.T) {
+	dir, err := os.MkdirTemp(workspaceRoot(), "git-test-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	cmd := exec.Command("git", "init", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	// stage file
+	cmd = exec.Command("git", "-C", dir, "add", "foo.txt")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v (%s)", err, out)
+	}
+	resp := Commit(context.Background(), CommitRequest{Path: dir, Message: "init"})
+	if resp.ExitCode != 0 {
+		t.Fatalf("commit failed: %v", resp.Error)
+	}
+	stat := Status(context.Background(), StatusRequest{Path: dir})
+	if stat.ExitCode != 0 {
+		t.Fatalf("status exit %d: %v", stat.ExitCode, stat.Error)
+	}
+	if stat.Stdout != "" {
+		t.Fatalf("expected clean repo, got %q", stat.Stdout)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gaspardpetit/mcp-shell/internal/archive"
 	"github.com/gaspardpetit/mcp-shell/internal/doc"
 	"github.com/gaspardpetit/mcp-shell/internal/fs"
+	"github.com/gaspardpetit/mcp-shell/internal/git"
 	"github.com/gaspardpetit/mcp-shell/internal/pkgmgr"
 	rt "github.com/gaspardpetit/mcp-shell/internal/runtime"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
@@ -383,6 +384,106 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "doc.metadata result"), nil
 	})
 	s.AddTool(docMetaTool, docMetaHandler)
+
+	// git.clone
+	cloneTool := mcp.NewTool(
+		"git.clone",
+		mcp.WithDescription("Clone a git repository"),
+		mcp.WithInputSchema[git.CloneRequest](),
+	)
+	cloneHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.CloneRequest) (*mcp.CallToolResult, error) {
+		resp := git.Clone(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.clone result"), nil
+	})
+	s.AddTool(cloneTool, cloneHandler)
+
+	statusTool := mcp.NewTool(
+		"git.status",
+		mcp.WithDescription("Get git status"),
+		mcp.WithInputSchema[git.StatusRequest](),
+	)
+	statusHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.StatusRequest) (*mcp.CallToolResult, error) {
+		resp := git.Status(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.status result"), nil
+	})
+	s.AddTool(statusTool, statusHandler)
+
+	commitTool := mcp.NewTool(
+		"git.commit",
+		mcp.WithDescription("Commit changes in a git repository"),
+		mcp.WithInputSchema[git.CommitRequest](),
+	)
+	commitHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.CommitRequest) (*mcp.CallToolResult, error) {
+		resp := git.Commit(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.commit result"), nil
+	})
+	s.AddTool(commitTool, commitHandler)
+
+	pullTool := mcp.NewTool(
+		"git.pull",
+		mcp.WithDescription("Pull latest changes"),
+		mcp.WithInputSchema[git.PullRequest](),
+	)
+	pullHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.PullRequest) (*mcp.CallToolResult, error) {
+		resp := git.Pull(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.pull result"), nil
+	})
+	s.AddTool(pullTool, pullHandler)
+
+	pushTool := mcp.NewTool(
+		"git.push",
+		mcp.WithDescription("Push commits to remote"),
+		mcp.WithInputSchema[git.PushRequest](),
+	)
+	pushHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.PushRequest) (*mcp.CallToolResult, error) {
+		resp := git.Push(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.push result"), nil
+	})
+	s.AddTool(pushTool, pushHandler)
+
+	checkoutTool := mcp.NewTool(
+		"git.checkout",
+		mcp.WithDescription("Checkout a git ref"),
+		mcp.WithInputSchema[git.CheckoutRequest](),
+	)
+	checkoutHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.CheckoutRequest) (*mcp.CallToolResult, error) {
+		resp := git.Checkout(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.checkout result"), nil
+	})
+	s.AddTool(checkoutTool, checkoutHandler)
+
+	branchTool := mcp.NewTool(
+		"git.branch",
+		mcp.WithDescription("Manage git branches"),
+		mcp.WithInputSchema[git.BranchRequest](),
+	)
+	branchHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.BranchRequest) (*mcp.CallToolResult, error) {
+		resp := git.Branch(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.branch result"), nil
+	})
+	s.AddTool(branchTool, branchHandler)
+
+	tagTool := mcp.NewTool(
+		"git.tag",
+		mcp.WithDescription("Manage git tags"),
+		mcp.WithInputSchema[git.TagRequest](),
+	)
+	tagHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.TagRequest) (*mcp.CallToolResult, error) {
+		resp := git.Tag(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.tag result"), nil
+	})
+	s.AddTool(tagTool, tagHandler)
+
+	lfsTool := mcp.NewTool(
+		"git.lfs.install",
+		mcp.WithDescription("Install Git LFS in a repository"),
+		mcp.WithInputSchema[git.LFSInstallRequest](),
+	)
+	lfsHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args git.LFSInstallRequest) (*mcp.CallToolResult, error) {
+		resp := git.LFSInstall(ctx, args)
+		return mcp.NewToolResultStructured(resp, "git.lfs.install result"), nil
+	})
+	s.AddTool(lfsTool, lfsHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add git utility tools for clone, status, commit, pull, push, checkout, branch, tag, and LFS install
- register new git.* tools and document them in README and doc/functions.md
- include tests and env guards for egress and pushes

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a74f40a848832ca7d0a7312be19fac