### PR TITLE
chore: add searxng service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,32 @@ RUN go build -trimpath -ldflags="-s -w" -o /out/mcp-server ./main.go
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# Install and configure local SearxNG instance
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libffi-dev \
+    libssl-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --no-cache-dir pyyaml setuptools \
+  && pip install --no-cache-dir --no-build-isolation git+https://github.com/searxng/searxng.git \
+  && mkdir -p /etc/searxng \
+  && python3 - <<'PY'
+import os, shutil, searx
+shutil.copyfile(os.path.join(os.path.dirname(searx.__file__), 'settings.yml'), '/etc/searxng/settings.yml')
+PY
+  && sed -i 's/ultrasecretkey/mcp-shell-secret/' /etc/searxng/settings.yml \
+  && sed -i 's/port: 8888/port: 8080/' /etc/searxng/settings.yml \
+  && sed -i 's/bind_address: "127.0.0.1"/bind_address: 0.0.0.0/' /etc/searxng/settings.yml \
+  && sed -i 's/public_instance: false/public_instance: true/' /etc/searxng/settings.yml
+
 COPY --from=builder /out/mcp-server /app/mcp-server
+
+# Start SearxNG alongside the MCP server
+RUN printf '#!/bin/bash\nset -e\nSEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml searxng-run &\nexec /app/mcp-server "$@"\n' > /start.sh \
+  && chmod +x /start.sh
 
 # Healthcheck matches server endpoints
 HEALTHCHECK --interval=30s --timeout=4s --start-period=10s --retries=3 \
@@ -22,5 +47,5 @@ HEALTHCHECK --interval=30s --timeout=4s --start-period=10s --retries=3 \
     || curl -fsS "http://127.0.0.1:${PORT}/mcp/health" >/dev/null \
     || exit 1
 
-ENTRYPOINT ["/app/mcp-server"]
+ENTRYPOINT ["/start.sh"]
 CMD ["--transport=http", "--addr=0.0.0.0:3333", "--log-dir=/logs", "--egress=0"]


### PR DESCRIPTION
## Summary
- install and configure local SearxNG search service
- launch SearxNG alongside the Go MCP server

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7719f2dcc832cad98f76f850a6069