### PR TITLE
feat: add web http request and download tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `git.*` (clone, status, commit, pull, push, etc.), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, and document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, and `doc.metadata`.
+- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `git.*` (clone, status, commit, pull, push, etc.), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, `doc.metadata`, and web tools like `http.request` and `web.download`.
 - **Dependencies**: `fs.search` relies on the `rg` binary (ripgrep); document tools rely on `pandoc`.
   Development dependencies are listed in `scripts/deps.txt` and can be installed via `scripts/install-deps.sh`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -44,3 +44,5 @@ List of functions exposed by `mcp-shell`.
 | `git.branch` | `path` (string, required), `name?`, `delete?`, `list?`, `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, branches?, error?}` | Manage branches |
 | `git.tag` | `path` (string, required), `name?`, `delete?`, `list?`, `timeout_ms?`, `max_bytes?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, tags?, error?}` | Manage tags |
 | `git.lfs.install` | `path` (string, required), `timeout_ms?`, `max_bytes?`, `dry_run?` | `{stdout, stderr, exit_code, duration_ms, stdout_truncated, stderr_truncated, error?}` | Install Git LFS in a repository |
+| `http.request` | `method` (string), `url` (string), `headers?`, `body?`, `body_b64?`, `timeout_ms?`, `max_bytes?`, `allow_insecure_tls?` | `{status, headers, body?, body_b64?, truncated, duration_ms, error?}` | Perform an HTTP request |
+| `web.download` | `url` (string), `dest_path` (string), `expected_sha256?`, `timeout_ms?`, `allow_insecure_tls?` | `{path, size, sha256, duration_ms, error?}` | Download a file from the web |

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -1,0 +1,271 @@
+package web
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	DefaultTimeout       = 60 * time.Second
+	DefaultMaxBody int64 = 1 << 20 // 1 MiB
+	LogPath              = "/logs/mcp-shell.log"
+)
+
+func egressAllowed() bool {
+	return os.Getenv("EGRESS") == "1"
+}
+
+// workspace root for downloads
+func workspaceRoot() string {
+	if ws := os.Getenv("WORKSPACE"); ws != "" {
+		return filepath.Clean(ws)
+	}
+	return "/workspace"
+}
+
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("dest_path is required")
+	}
+	root := workspaceRoot()
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(root, p)
+	}
+	p = filepath.Clean(p)
+	rel, err := filepath.Rel(root, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", errors.New("path escapes workspace")
+	}
+	return p, nil
+}
+
+// ---- http.request ----
+
+type HTTPRequest struct {
+	Method           string            `json:"method"`
+	URL              string            `json:"url"`
+	Headers          map[string]string `json:"headers,omitempty"`
+	Body             string            `json:"body,omitempty"`
+	BodyB64          string            `json:"body_b64,omitempty"`
+	TimeoutMs        int               `json:"timeout_ms,omitempty"`
+	MaxBytes         int64             `json:"max_bytes,omitempty"`
+	AllowInsecureTLS bool              `json:"allow_insecure_tls,omitempty"`
+}
+
+type HTTPResponse struct {
+	Status     int                 `json:"status"`
+	Headers    map[string][]string `json:"headers"`
+	Body       string              `json:"body,omitempty"`
+	BodyB64    string              `json:"body_b64,omitempty"`
+	Truncated  bool                `json:"truncated"`
+	DurationMs int64               `json:"duration_ms"`
+	Error      string              `json:"error,omitempty"`
+}
+
+func HTTPRequestTool(ctx context.Context, in HTTPRequest) HTTPResponse {
+	start := time.Now()
+	if !egressAllowed() {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: "egress disabled"}
+	}
+	if in.Method == "" {
+		in.Method = http.MethodGet
+	}
+	if in.URL == "" {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: "url is required"}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	limit := DefaultMaxBody
+	if in.MaxBytes > 0 {
+		limit = in.MaxBytes
+	}
+	var bodyReader io.Reader
+	if in.Body != "" && in.BodyB64 != "" {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: "body and body_b64 are mutually exclusive"}
+	}
+	if in.Body != "" {
+		bodyReader = strings.NewReader(in.Body)
+	} else if in.BodyB64 != "" {
+		b, err := base64.StdEncoding.DecodeString(in.BodyB64)
+		if err != nil {
+			return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: "invalid body_b64"}
+		}
+		bodyReader = strings.NewReader(string(b))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, in.Method, in.URL, bodyReader)
+	if err != nil {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	for k, v := range in.Headers {
+		req.Header.Set(k, v)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if in.AllowInsecureTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{Transport: transport}
+	resp, err := client.Do(req)
+	if err != nil {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	limited := io.LimitReader(resp.Body, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return HTTPResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	truncated := int64(len(data)) > limit
+	if truncated {
+		data = data[:int(limit)]
+	}
+	out := HTTPResponse{Status: resp.StatusCode, Headers: resp.Header, Truncated: truncated}
+	if utf8.Valid(data) {
+		out.Body = string(data)
+	} else {
+		out.BodyB64 = base64.StdEncoding.EncodeToString(data)
+	}
+	out.DurationMs = time.Since(start).Milliseconds()
+	auditHTTPRequest(in, out, len(data))
+	return out
+}
+
+// ---- web.download ----
+
+type DownloadRequest struct {
+	URL              string `json:"url"`
+	DestPath         string `json:"dest_path"`
+	ExpectedSHA256   string `json:"expected_sha256,omitempty"`
+	TimeoutMs        int    `json:"timeout_ms,omitempty"`
+	AllowInsecureTLS bool   `json:"allow_insecure_tls,omitempty"`
+}
+
+type DownloadResponse struct {
+	Path       string `json:"path"`
+	Size       int64  `json:"size"`
+	Sha256     string `json:"sha256"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func Download(ctx context.Context, in DownloadRequest) DownloadResponse {
+	start := time.Now()
+	if !egressAllowed() {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: "egress disabled"}
+	}
+	if in.URL == "" || in.DestPath == "" {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: "url and dest_path are required"}
+	}
+	dest, err := normalizePath(in.DestPath)
+	if err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, in.URL, nil)
+	if err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if in.AllowInsecureTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{Transport: transport}
+	resp, err := client.Do(req)
+	if err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: resp.Status}
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	defer f.Close()
+	hash := sha256.New()
+	size, err := io.Copy(io.MultiWriter(f, hash), resp.Body)
+	if err != nil {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: err.Error()}
+	}
+	sum := hex.EncodeToString(hash.Sum(nil))
+	if in.ExpectedSHA256 != "" && !strings.EqualFold(sum, in.ExpectedSHA256) {
+		return DownloadResponse{DurationMs: time.Since(start).Milliseconds(), Error: "sha256 mismatch"}
+	}
+	out := DownloadResponse{Path: dest, Size: size, Sha256: sum, DurationMs: time.Since(start).Milliseconds()}
+	auditDownload(in, out)
+	return out
+}
+
+func auditHTTPRequest(in HTTPRequest, out HTTPResponse, bytesOut int) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	rec := struct {
+		TS        string `json:"ts"`
+		Tool      string `json:"tool"`
+		Method    string `json:"method"`
+		URL       string `json:"url"`
+		Status    int    `json:"status"`
+		Duration  int64  `json:"duration_ms"`
+		BytesOut  int    `json:"bytes_out"`
+		Truncated bool   `json:"truncated"`
+	}{time.Now().UTC().Format(time.RFC3339), "http.request", in.Method, in.URL, out.Status, out.DurationMs, bytesOut, out.Truncated}
+	_ = json.NewEncoder(f).Encode(rec)
+}
+
+func auditDownload(in DownloadRequest, out DownloadResponse) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	rec := struct {
+		TS       string `json:"ts"`
+		Tool     string `json:"tool"`
+		URL      string `json:"url"`
+		Dest     string `json:"dest"`
+		Size     int64  `json:"size"`
+		Sha256   string `json:"sha256"`
+		Duration int64  `json:"duration_ms"`
+	}{time.Now().UTC().Format(time.RFC3339), "web.download", in.URL, out.Path, out.Size, out.Sha256, out.DurationMs}
+	_ = json.NewEncoder(f).Encode(rec)
+}

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -1,0 +1,56 @@
+package web
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHTTPRequestTool(t *testing.T) {
+	os.Setenv("EGRESS", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Test") != "1" {
+			t.Errorf("missing header")
+		}
+		w.Write([]byte("abcdef"))
+	}))
+	defer srv.Close()
+	resp := HTTPRequestTool(context.Background(), HTTPRequest{Method: "GET", URL: srv.URL, Headers: map[string]string{"X-Test": "1"}, MaxBytes: 3})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected status 200, got %d", resp.Status)
+	}
+	if resp.Body != "abc" || !resp.Truncated {
+		t.Fatalf("unexpected body %q truncated=%v", resp.Body, resp.Truncated)
+	}
+}
+
+func TestDownload(t *testing.T) {
+	t.Setenv("EGRESS", "1")
+	t.Setenv("WORKSPACE", t.TempDir())
+	data := []byte("download me")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer srv.Close()
+	sum := sha256.Sum256(data)
+	dest := filepath.Join(workspaceRoot(), "download.test")
+	defer os.Remove(dest)
+	resp := Download(context.Background(), DownloadRequest{URL: srv.URL, DestPath: dest, ExpectedSHA256: hex.EncodeToString(sum[:])})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if resp.Size != int64(len(data)) {
+		t.Fatalf("expected size %d, got %d", len(data), resp.Size)
+	}
+	if resp.Sha256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("sha mismatch")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	rt "github.com/gaspardpetit/mcp-shell/internal/runtime"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
 	"github.com/gaspardpetit/mcp-shell/internal/text"
+	"github.com/gaspardpetit/mcp-shell/internal/web"
 )
 
 var (
@@ -484,6 +485,30 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "git.lfs.install result"), nil
 	})
 	s.AddTool(lfsTool, lfsHandler)
+
+	// http.request
+	httpTool := mcp.NewTool(
+		"http.request",
+		mcp.WithDescription("Perform an HTTP request"),
+		mcp.WithInputSchema[web.HTTPRequest](),
+	)
+	httpHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args web.HTTPRequest) (*mcp.CallToolResult, error) {
+		resp := web.HTTPRequestTool(ctx, args)
+		return mcp.NewToolResultStructured(resp, "http.request result"), nil
+	})
+	s.AddTool(httpTool, httpHandler)
+
+	// web.download
+	dlTool := mcp.NewTool(
+		"web.download",
+		mcp.WithDescription("Download a file from the web"),
+		mcp.WithInputSchema[web.DownloadRequest](),
+	)
+	dlHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args web.DownloadRequest) (*mcp.CallToolResult, error) {
+		resp := web.Download(ctx, args)
+		return mcp.NewToolResultStructured(resp, "web.download result"), nil
+	})
+	s.AddTool(dlTool, dlHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add `http.request` and `web.download` tools with egress guard and logging
- document new web tools in README and function reference
- cover http request and download utilities with tests
- ensure download test uses an isolated workspace

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a76bd35668832c83f686a5726e0011