### PR TITLE
feat: add process management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 
 - **Purpose**: Let an LLM run commands, inspect/transform files, process documents (Word/Excel/PowerPoint/PDF), and use common CLIs (Python, Node.js, Git, jq/yq, ripgrep, ImageMagick, ffmpeg, Tesseract, Pandoc, Poppler, DuckDB CLI, etc.).
-- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `git.*` (clone, status, commit, pull, push, etc.), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, `doc.metadata`, and web tools like `http.request`, `web.download`, `web.search`, and `md.fetch`.
+- **Primary tools**: `shell.exec`, `python.run`, `node.run`, `sh.script.write_and_run`, package managers (`apt.install`, `pip.install`, `npm.install`), `git.*` (clone, status, commit, pull, push, etc.), `fs.*` (list, stat, read, write, search, hash, etc.), `archive.*`, text utilities like `text.diff` and `text.apply_patch`, document helpers such as `doc.convert`, `pdf.extract_text`, `spreadsheet.to_csv`, `doc.metadata`, and web tools like `http.request`, `web.download`, `web.search`, and `md.fetch`, and process tools like `proc.spawn`, `proc.stdin`, `proc.wait`, `proc.kill`, `proc.list`.
 - **Dependencies**: `fs.search` relies on the `rg` binary (ripgrep); document tools rely on `pandoc`.
   Development dependencies are listed in `scripts/deps.txt` and can be installed via `scripts/install-deps.sh`.
 - **Function reference**: see [doc/functions.md](doc/functions.md) for supported functions.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -48,3 +48,8 @@ List of functions exposed by `mcp-shell`.
 | `web.download` | `url` (string), `dest_path` (string), `expected_sha256?`, `timeout_ms?`, `allow_insecure_tls?` | `{path, size, sha256, duration_ms, error?}` | Download a file from the web |
 | `web.search` | `query` (string), `num_results?`, `engines?`, `safesearch?`, `time_range?`, `language?`, `timeout_ms?` | `{results:[{title,url,snippet,published?,source}],duration_ms,error?}` | Metasearch via SearxNG |
 | `md.fetch` | `url` (string), `timeout_ms?`, `max_bytes?`, `allow_insecure_tls?`, `render_js?`, `save_artifacts?` | `{title?,byline?,site_name?,published?,canonical_url?,markdown,truncated,artifacts?,duration_ms,error?}` | Fetch webpage and extract main content as Markdown |
+| `proc.spawn` | `cmd` (string, required), `args?`, `cwd?`, `env?`, `tty?` | `{pid, duration_ms, error?}` | Spawn a long-running process |
+| `proc.stdin` | `pid` (int, required), `data` (string, required) | `{bytes_written, duration_ms, error?}` | Write to stdin of a spawned process |
+| `proc.wait` | `pid` (int, required), `timeout_ms?` | `{exit_code, stdout?, stderr?, truncated, duration_ms, error?}` | Wait for a spawned process to exit |
+| `proc.kill` | `pid` (int, required), `signal?` (int) | `{killed, duration_ms, error?}` | Send a signal to a spawned process |
+| `proc.list` | none | `{processes:[{pid,cmdline,start_time,cwd}], duration_ms, error?}` | List spawned processes |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.6
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
+	github.com/creack/pty v1.1.21
 	github.com/go-shiori/go-readability v0.0.0-20250217085726-9f5bf5ca7612
 	github.com/mark3labs/mcp-go v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -1,0 +1,362 @@
+package proc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+const (
+	DefaultTimeout  = 60 * time.Second
+	DefaultMaxIO    = 1 << 20 // 1 MiB
+	DefaultMaxStdin = 1 << 20 // 1 MiB
+	LogPath         = "/logs/mcp-shell.log"
+)
+
+type SpawnRequest struct {
+	Cmd  string            `json:"cmd"`
+	Args []string          `json:"args,omitempty"`
+	Cwd  string            `json:"cwd,omitempty"`
+	Env  map[string]string `json:"env,omitempty"`
+	TTY  bool              `json:"tty,omitempty"`
+}
+
+type SpawnResponse struct {
+	Pid        int    `json:"pid,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+type StdinRequest struct {
+	Pid  int    `json:"pid"`
+	Data string `json:"data"`
+}
+
+type StdinResponse struct {
+	BytesWritten int    `json:"bytes_written"`
+	DurationMs   int64  `json:"duration_ms"`
+	Error        string `json:"error,omitempty"`
+}
+
+type WaitRequest struct {
+	Pid       int `json:"pid"`
+	TimeoutMs int `json:"timeout_ms,omitempty"`
+}
+
+type WaitResponse struct {
+	ExitCode   int    `json:"exit_code"`
+	Stdout     string `json:"stdout,omitempty"`
+	Stderr     string `json:"stderr,omitempty"`
+	Truncated  bool   `json:"truncated"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+type KillRequest struct {
+	Pid    int `json:"pid"`
+	Signal int `json:"signal,omitempty"`
+}
+
+type KillResponse struct {
+	Killed     bool   `json:"killed"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+type ListRequest struct{}
+
+type ListResponse struct {
+	Processes  []ProcInfo `json:"processes"`
+	DurationMs int64      `json:"duration_ms"`
+}
+
+type ProcInfo struct {
+	Pid       int    `json:"pid"`
+	Cmdline   string `json:"cmdline"`
+	StartTime string `json:"start_time"`
+	Cwd       string `json:"cwd,omitempty"`
+}
+
+type process struct {
+	cmd         *exec.Cmd
+	stdin       io.WriteCloser
+	stdoutBuf   *bytes.Buffer
+	stderrBuf   *bytes.Buffer
+	stdoutTrunc *bool
+	stderrTrunc *bool
+	done        chan struct{}
+	exitCode    int
+	start       time.Time
+	cwd         string
+	tty         bool
+}
+
+var (
+	procMu    sync.Mutex
+	processes = make(map[int]*process)
+)
+
+type limitedWriter struct {
+	buf       *bytes.Buffer
+	limit     int
+	truncated *bool
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		return w.buf.Write(p)
+	}
+	remain := w.limit - w.buf.Len()
+	if remain <= 0 {
+		*w.truncated = true
+		return len(p), nil
+	}
+	if len(p) <= remain {
+		return w.buf.Write(p)
+	}
+	_, _ = w.buf.Write(p[:remain])
+	*w.truncated = true
+	return len(p), nil
+}
+
+func Spawn(ctx context.Context, in SpawnRequest) SpawnResponse {
+	start := time.Now()
+	if in.Cmd == "" {
+		return SpawnResponse{Error: "cmd is required", DurationMs: time.Since(start).Milliseconds()}
+	}
+
+	cmd := exec.Command(in.Cmd, in.Args...)
+	if in.Cwd != "" {
+		cmd.Dir = filepath.Clean(in.Cwd)
+	} else if ws := os.Getenv("WORKSPACE"); ws != "" {
+		cmd.Dir = ws
+	}
+	if len(in.Env) > 0 {
+		env := os.Environ()
+		for k, v := range in.Env {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = env
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var (
+		stdoutBuf, stderrBuf     bytes.Buffer
+		stdoutTrunc, stderrTrunc bool
+		stdin                    io.WriteCloser
+		err                      error
+	)
+
+	if in.TTY {
+		var f *os.File
+		f, err = pty.Start(cmd)
+		if err != nil {
+			return SpawnResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+		}
+		stdin = f
+		go func() {
+			_, _ = io.Copy(&limitedWriter{buf: &stdoutBuf, limit: DefaultMaxIO, truncated: &stdoutTrunc}, f)
+		}()
+	} else {
+		var stdoutPipe, stderrPipe io.ReadCloser
+		stdoutPipe, err = cmd.StdoutPipe()
+		if err != nil {
+			return SpawnResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+		}
+		stderrPipe, err = cmd.StderrPipe()
+		if err != nil {
+			return SpawnResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+		}
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			return SpawnResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+		}
+		go func() {
+			_, _ = io.Copy(&limitedWriter{buf: &stdoutBuf, limit: DefaultMaxIO, truncated: &stdoutTrunc}, stdoutPipe)
+		}()
+		go func() {
+			_, _ = io.Copy(&limitedWriter{buf: &stderrBuf, limit: DefaultMaxIO, truncated: &stderrTrunc}, stderrPipe)
+		}()
+	}
+
+	if err = cmd.Start(); err != nil {
+		return SpawnResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+
+	p := &process{
+		cmd:         cmd,
+		stdin:       stdin,
+		stdoutBuf:   &stdoutBuf,
+		stderrBuf:   &stderrBuf,
+		stdoutTrunc: &stdoutTrunc,
+		stderrTrunc: &stderrTrunc,
+		done:        make(chan struct{}),
+		start:       time.Now(),
+		cwd:         cmd.Dir,
+		tty:         in.TTY,
+	}
+
+	procMu.Lock()
+	processes[cmd.Process.Pid] = p
+	procMu.Unlock()
+
+	go func() {
+		err := cmd.Wait()
+		exit := 0
+		if err != nil {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				exit = ee.ExitCode()
+			} else {
+				exit = 1
+			}
+		}
+		p.exitCode = exit
+		close(p.done)
+	}()
+
+	audit(struct {
+		TS   string `json:"ts"`
+		Tool string `json:"tool"`
+		Cmd  string `json:"cmd"`
+		PID  int    `json:"pid"`
+		Cwd  string `json:"cwd"`
+	}{time.Now().UTC().Format(time.RFC3339), "proc.spawn", cmd.String(), cmd.Process.Pid, cmd.Dir})
+
+	return SpawnResponse{Pid: cmd.Process.Pid, DurationMs: time.Since(start).Milliseconds()}
+}
+
+func Stdin(ctx context.Context, in StdinRequest) StdinResponse {
+	start := time.Now()
+	procMu.Lock()
+	p := processes[in.Pid]
+	procMu.Unlock()
+	if p == nil {
+		return StdinResponse{Error: "unknown pid", DurationMs: time.Since(start).Milliseconds()}
+	}
+	data := []byte(in.Data)
+	if len(data) > DefaultMaxStdin {
+		data = data[:DefaultMaxStdin]
+	}
+	n, err := p.stdin.Write(data)
+	if err != nil {
+		return StdinResponse{BytesWritten: n, Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	audit(struct {
+		TS    string `json:"ts"`
+		Tool  string `json:"tool"`
+		PID   int    `json:"pid"`
+		Bytes int    `json:"bytes"`
+	}{time.Now().UTC().Format(time.RFC3339), "proc.stdin", in.Pid, n})
+	return StdinResponse{BytesWritten: n, DurationMs: time.Since(start).Milliseconds()}
+}
+
+func Wait(ctx context.Context, in WaitRequest) WaitResponse {
+	start := time.Now()
+	procMu.Lock()
+	p := processes[in.Pid]
+	procMu.Unlock()
+	if p == nil {
+		return WaitResponse{ExitCode: 1, Error: "unknown pid", DurationMs: time.Since(start).Milliseconds()}
+	}
+	timeout := DefaultTimeout
+	if in.TimeoutMs > 0 {
+		timeout = time.Duration(in.TimeoutMs) * time.Millisecond
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	select {
+	case <-p.done:
+	case <-ctx.Done():
+		return WaitResponse{ExitCode: 124, Stdout: p.stdoutBuf.String(), Stderr: p.stderrBuf.String(), Truncated: *p.stdoutTrunc || *p.stderrTrunc, DurationMs: time.Since(start).Milliseconds(), Error: "timeout"}
+	}
+	resp := WaitResponse{
+		ExitCode:   p.exitCode,
+		Stdout:     p.stdoutBuf.String(),
+		Stderr:     p.stderrBuf.String(),
+		Truncated:  *p.stdoutTrunc || *p.stderrTrunc,
+		DurationMs: time.Since(start).Milliseconds(),
+	}
+	audit(struct {
+		TS       string `json:"ts"`
+		Tool     string `json:"tool"`
+		PID      int    `json:"pid"`
+		Exit     int    `json:"exit"`
+		BytesOut int    `json:"bytes_out"`
+	}{time.Now().UTC().Format(time.RFC3339), "proc.wait", in.Pid, resp.ExitCode, len(resp.Stdout) + len(resp.Stderr)})
+	procMu.Lock()
+	delete(processes, in.Pid)
+	procMu.Unlock()
+	return resp
+}
+
+func Kill(ctx context.Context, in KillRequest) KillResponse {
+	start := time.Now()
+	procMu.Lock()
+	p := processes[in.Pid]
+	procMu.Unlock()
+	if p == nil || p.cmd.Process == nil {
+		return KillResponse{Error: "unknown pid", DurationMs: time.Since(start).Milliseconds()}
+	}
+	sig := syscall.SIGTERM
+	if in.Signal != 0 {
+		sig = syscall.Signal(in.Signal)
+	}
+	err := syscall.Kill(-p.cmd.Process.Pid, sig)
+	if err != nil {
+		return KillResponse{Error: err.Error(), DurationMs: time.Since(start).Milliseconds()}
+	}
+	audit(struct {
+		TS     string `json:"ts"`
+		Tool   string `json:"tool"`
+		PID    int    `json:"pid"`
+		Signal int    `json:"signal"`
+	}{time.Now().UTC().Format(time.RFC3339), "proc.kill", in.Pid, int(sig)})
+	return KillResponse{Killed: true, DurationMs: time.Since(start).Milliseconds()}
+}
+
+func List(ctx context.Context, _ ListRequest) ListResponse {
+	start := time.Now()
+	procMu.Lock()
+	defer procMu.Unlock()
+	res := ListResponse{DurationMs: time.Since(start).Milliseconds()}
+	for pid, p := range processes {
+		res.Processes = append(res.Processes, ProcInfo{
+			Pid:       pid,
+			Cmdline:   p.cmd.String(),
+			StartTime: p.start.UTC().Format(time.RFC3339),
+			Cwd:       p.cwd,
+		})
+	}
+	audit(struct {
+		TS    string `json:"ts"`
+		Tool  string `json:"tool"`
+		Count int    `json:"count"`
+	}{time.Now().UTC().Format(time.RFC3339), "proc.list", len(res.Processes)})
+	return res
+}
+
+func audit(rec any) {
+	if LogPath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(LogPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(rec)
+}

--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -1,0 +1,74 @@
+package proc
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSpawnStdinWait(t *testing.T) {
+	ctx := context.Background()
+	resp := Spawn(ctx, SpawnRequest{Cmd: "bash", Args: []string{"-c", "read line; echo hi $line"}})
+	if resp.Error != "" {
+		t.Fatalf("spawn error: %v", resp.Error)
+	}
+	pid := resp.Pid
+	defer Kill(ctx, KillRequest{Pid: pid, Signal: int(syscall.SIGKILL)})
+
+	sresp := Stdin(ctx, StdinRequest{Pid: pid, Data: "world\n"})
+	if sresp.Error != "" {
+		t.Fatalf("stdin error: %v", sresp.Error)
+	}
+	wresp := Wait(ctx, WaitRequest{Pid: pid, TimeoutMs: 5000})
+	if wresp.Error != "" {
+		t.Fatalf("wait error: %v", wresp.Error)
+	}
+	if wresp.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", wresp.ExitCode)
+	}
+	if wresp.Stdout != "hi world\n" {
+		t.Fatalf("unexpected stdout: %q", wresp.Stdout)
+	}
+}
+
+func TestKill(t *testing.T) {
+	ctx := context.Background()
+	resp := Spawn(ctx, SpawnRequest{Cmd: "sleep", Args: []string{"1000"}})
+	if resp.Error != "" {
+		t.Fatalf("spawn error: %v", resp.Error)
+	}
+	pid := resp.Pid
+	kresp := Kill(ctx, KillRequest{Pid: pid})
+	if kresp.Error != "" || !kresp.Killed {
+		t.Fatalf("kill failed: %+v", kresp)
+	}
+	wresp := Wait(ctx, WaitRequest{Pid: pid, TimeoutMs: 5000})
+	if wresp.Error != "" {
+		t.Fatalf("wait error: %v", wresp.Error)
+	}
+	if wresp.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit after kill")
+	}
+}
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	resp := Spawn(ctx, SpawnRequest{Cmd: "sleep", Args: []string{"1"}})
+	if resp.Error != "" {
+		t.Fatalf("spawn error: %v", resp.Error)
+	}
+	pid := resp.Pid
+	found := false
+	l := List(ctx, ListRequest{})
+	for _, p := range l.Processes {
+		if p.Pid == pid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("pid %d not in list", pid)
+	}
+	_ = Wait(ctx, WaitRequest{Pid: pid, TimeoutMs: int(2 * time.Second.Milliseconds())})
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gaspardpetit/mcp-shell/internal/fs"
 	"github.com/gaspardpetit/mcp-shell/internal/git"
 	"github.com/gaspardpetit/mcp-shell/internal/pkgmgr"
+	"github.com/gaspardpetit/mcp-shell/internal/proc"
 	rt "github.com/gaspardpetit/mcp-shell/internal/runtime"
 	"github.com/gaspardpetit/mcp-shell/internal/shell"
 	"github.com/gaspardpetit/mcp-shell/internal/text"
@@ -533,6 +534,62 @@ func main() {
 		return mcp.NewToolResultStructured(resp, "md.fetch result"), nil
 	})
 	s.AddTool(mdTool, mdHandler)
+
+	// proc.spawn
+	spawnTool := mcp.NewTool(
+		"proc.spawn",
+		mcp.WithDescription("Spawn a long-running process"),
+		mcp.WithInputSchema[proc.SpawnRequest](),
+	)
+	spawnHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args proc.SpawnRequest) (*mcp.CallToolResult, error) {
+		resp := proc.Spawn(ctx, args)
+		return mcp.NewToolResultStructured(resp, "proc.spawn result"), nil
+	})
+	s.AddTool(spawnTool, spawnHandler)
+
+	stdinTool := mcp.NewTool(
+		"proc.stdin",
+		mcp.WithDescription("Write to stdin of a spawned process"),
+		mcp.WithInputSchema[proc.StdinRequest](),
+	)
+	stdinHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args proc.StdinRequest) (*mcp.CallToolResult, error) {
+		resp := proc.Stdin(ctx, args)
+		return mcp.NewToolResultStructured(resp, "proc.stdin result"), nil
+	})
+	s.AddTool(stdinTool, stdinHandler)
+
+	waitTool := mcp.NewTool(
+		"proc.wait",
+		mcp.WithDescription("Wait for a spawned process to exit"),
+		mcp.WithInputSchema[proc.WaitRequest](),
+	)
+	waitHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args proc.WaitRequest) (*mcp.CallToolResult, error) {
+		resp := proc.Wait(ctx, args)
+		return mcp.NewToolResultStructured(resp, "proc.wait result"), nil
+	})
+	s.AddTool(waitTool, waitHandler)
+
+	killTool := mcp.NewTool(
+		"proc.kill",
+		mcp.WithDescription("Send a signal to a spawned process"),
+		mcp.WithInputSchema[proc.KillRequest](),
+	)
+	killHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args proc.KillRequest) (*mcp.CallToolResult, error) {
+		resp := proc.Kill(ctx, args)
+		return mcp.NewToolResultStructured(resp, "proc.kill result"), nil
+	})
+	s.AddTool(killTool, killHandler)
+
+	listTool := mcp.NewTool(
+		"proc.list",
+		mcp.WithDescription("List spawned processes"),
+		mcp.WithInputSchema[proc.ListRequest](),
+	)
+	listHandler := mcp.NewTypedToolHandler(func(ctx context.Context, req mcp.CallToolRequest, args proc.ListRequest) (*mcp.CallToolResult, error) {
+		resp := proc.List(ctx, args)
+		return mcp.NewToolResultStructured(resp, "proc.list result"), nil
+	})
+	s.AddTool(listTool, listHandler)
 
 	// ---- context & signals
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Summary
- add process management package with spawn, stdin, wait, kill, and list tools
- register new proc tools in server
- document process tools in README and function reference

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9723bf4832c9b17a1d50411c2a7