### PR TITLE
fix: remove unsupported server flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ HEALTHCHECK --interval=30s --timeout=4s --start-period=10s --retries=3 \
     || exit 1
 
 ENTRYPOINT ["/start.sh"]
-CMD ["--transport=http", "--addr=0.0.0.0:3333", "--log-dir=/logs", "--egress=0"]
+CMD ["--transport=http", "--addr=0.0.0.0:3333"]


### PR DESCRIPTION
## Summary
- drop unsupported `--log-dir` and `--egress` flags from Dockerfile CMD so the container starts cleanly

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...` *(fails: missing `convert` and `ffmpeg` executables)*

------
https://chatgpt.com/codex/tasks/task_e_68a9704a77d4832c8beb24efc795aa75